### PR TITLE
immutable.jsを使用するように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@gitobi/react-blank-component": "^1.0.2",
     "amazon-cognito-identity-js": "^1.21.0",
     "eslint": "^4.9.0",
+    "immutable": "^3.8.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",

--- a/src/containers/DevicesWateringSchedules.js
+++ b/src/containers/DevicesWateringSchedules.js
@@ -139,8 +139,8 @@ class DevicesWateringSchedules extends React.Component {
 
 function mapStateToProps(state) {
   return  {
-    selectedDevicesWateringId: state.devicesWatering.selectedId,
-    devicesWateringSchedules: state.devicesWatering.schedules,
+    selectedDevicesWateringId: state.devicesWatering.get('selectedId'),
+    devicesWateringSchedules: state.devicesWatering.get('schedules').toJS(),
   };
 }
 

--- a/src/containers/DevicesWaterings.js
+++ b/src/containers/DevicesWaterings.js
@@ -61,8 +61,8 @@ class DevicesWaterings extends Component {
 
 function mapStateToProps(state) {
   return  {
-    devicesWaterings: state.devicesWatering.list,
-    selectedDevicesWateringId: state.devicesWatering.selectedId,
+    devicesWaterings: state.devicesWatering.get('list').toJS(),
+    selectedDevicesWateringId: state.devicesWatering.get('selectedId'),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3227,6 +3227,10 @@ ignore@^3.3.3:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
 
+immutable@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
actionsから
`data = Object.assign({}, state, {list: [...state.list]});`
みたいなロジックを一掃するために、immutable.jsを使用するように修正した。
まあ、ぶっちゃけimmutable.jsを使うと、object/arrayの要素に対しても.update()とか.set()とかのメソッドでアクセスする必要があるので、actionでの書き方がピュアjsっぽくなくなったので、うん、なんかうん。という感じですが、コード自体は凄くスッキリしました。

ご存知でしょうが、immutable.jsのdocs
https://facebook.github.io/immutable-js/docs/#/Map
