### PR TITLE
Feature/waterings/fix schedules edit 3

### DIFF
--- a/src/actions/devicesWatering.js
+++ b/src/actions/devicesWatering.js
@@ -139,7 +139,7 @@ export function saveDevicesWateringSchedules(schedules, changed) {
 
     return Promise.all(promises).then(
       result => dispatch({ type: DevicesWatering.SAVE_SCHEDULES_SUCCESS }),
-      error => dispatch({ type: DevicesWatering.SAVE_SCHEDULES_FAILURE })
+      error => dispatch({ type: DevicesWatering.SAVE_SCHEDULES_FAILURE, error: error })
     );
   }
 };

--- a/src/actions/devicesWatering.js
+++ b/src/actions/devicesWatering.js
@@ -79,62 +79,46 @@ export function saveDevicesWateringSchedules(schedules, changed) {
       // console.log('schedule', schedule);
       // console.log('params', params);
 
-      var promise = null;
-      if ('create' === params._state) {
+      switch (params._state) {
+       case 'create':
         // 新規
-        dispatch({ type: DevicesWatering.POST_SCHEDULES_REQUEST });
-        promise = bastet.createWateringsSchedule(params.device_id, params).then(
-          result => {
-            dispatch({
-              type: DevicesWatering.POST_SCHEDULES_SUCCESS,
-              change: change,
-              schedule: schedule,
-              params: params,
-              result: result.data.schedule,
-            });
-          },
-          error => {
-            dispatch({ type: DevicesWatering.POST_SCHEDULES_FAILURE });
-          }
-        );
+        promises.push(apiDevicesWateringSchedule(
+          dispatch,
+          DevicesWatering.POST_SCHEDULES_REQUEST,
+          DevicesWatering.POST_SCHEDULES_SUCCESS,
+          DevicesWatering.POST_SCHEDULES_FAILURE,
+          bastet,
+          bastet.createWateringsSchedule,
+          params,
+        ));
+        break;
 
-      } else if ('delete' === params._state) {
+      case 'delete':
         // 削除
-        dispatch({ type: DevicesWatering.DELETE_SCHEDULES_REQUEST });
-        promise = bastet.deleteWateringsSchedule(params.device_id, params.id).then(
-          result => {
-            dispatch({
-              type: DevicesWatering.DELETE_SCHEDULES_SUCCESS,
-              change: change,
-              schedule: schedule,
-              params: params,
-              result: result.data.schedule,
-            });
-          },
-          error => {
-            dispatch({ type: DevicesWatering.DELETE_SCHEDULES_FAILURE });
-          }
-        );
+        promises.push(apiDevicesWateringSchedule(
+          dispatch,
+          DevicesWatering.DELETE_SCHEDULES_REQUEST,
+          DevicesWatering.DELETE_SCHEDULES_SUCCESS,
+          DevicesWatering.DELETE_SCHEDULES_FAILURE,
+          bastet,
+          bastet.deleteWateringsSchedule,
+          params,
+        ));
+        break;
 
-      } else {
+      default:
         // 更新
-        dispatch({ type: DevicesWatering.PUT_SCHEDULES_REQUEST });
-        promise = bastet.updateWateringsSchedule(params.device_id, params.id, params).then(
-          result => {
-            dispatch({
-              type: DevicesWatering.PUT_SCHEDULES_SUCCESS,
-              change: change,
-              schedule: schedule,
-              params: params,
-              result: result.data.schedule,
-            });
-          },
-          error => {
-            dispatch({ type: DevicesWatering.PUT_SCHEDULES_FAILURE });
-          }
-        );
+        promises.push(apiDevicesWateringSchedule(
+          dispatch,
+          DevicesWatering.PUT_SCHEDULES_REQUEST,
+          DevicesWatering.PUT_SCHEDULES_SUCCESS,
+          DevicesWatering.PUT_SCHEDULES_FAILURE,
+          bastet,
+          bastet.updateWateringsSchedule,
+          params,
+        ));
+        break
       }
-      promises.push(promise);
     });
 
     return Promise.all(promises).then(
@@ -163,6 +147,45 @@ export function updateDevicesWateringSchedule(id, column, value) {
     value: value,
   };
 };
+
+/**
+ * Api For DevicesWateringSchedule Wrapper
+ * @param  {[type]} dispatch          [description]
+ * @param  {[type]} actionTypeRequest [description]
+ * @param  {[type]} actionTypeSuccess [description]
+ * @param  {[type]} actionTypeFailure [description]
+ * @param  {[type]} bastet            [description]
+ * @param  {[type]} bastetApi         [description]
+ * @param  {[type]} params            [description]
+ * @param  {[type]}                   [description]
+ * @return {[type]}                   [description]
+ */
+const apiDevicesWateringSchedule = (
+  dispatch,
+  actionTypeRequest,
+  actionTypeSuccess,
+  actionTypeFailure,
+  bastet,
+  bastetApi,
+  params,
+  ) => {
+  dispatch({ type: actionTypeRequest });
+  return bastetApi.call(bastet, params.device_id, params).then(
+    result => {
+      dispatch({
+        type: actionTypeSuccess,
+        params: params,
+        result: result.data.schedule,
+      });
+    },
+    error => {
+      dispatch({
+        type: actionTypeFailure,
+        error: error,
+      });
+    }
+  );
+}
 
 /**
  * FOR DEBUG

--- a/src/actions/devicesWatering.js
+++ b/src/actions/devicesWatering.js
@@ -157,7 +157,6 @@ export function updateDevicesWateringSchedule(id, column, value) {
  * @param  {[type]} bastet            [description]
  * @param  {[type]} bastetApi         [description]
  * @param  {[type]} params            [description]
- * @param  {[type]}                   [description]
  * @return {[type]}                   [description]
  */
 const apiDevicesWateringSchedule = (
@@ -167,7 +166,7 @@ const apiDevicesWateringSchedule = (
   actionTypeFailure,
   bastet,
   bastetApi,
-  params,
+  params
   ) => {
   dispatch({ type: actionTypeRequest });
   return bastetApi.call(bastet, params.device_id, params).then(

--- a/src/actions/devicesWatering.js
+++ b/src/actions/devicesWatering.js
@@ -90,7 +90,7 @@ export function saveDevicesWateringSchedules(schedules, changed) {
               change: change,
               schedule: schedule,
               params: params,
-              result: result.data.schedules,
+              result: result.data.schedule,
             });
           },
           error => {
@@ -108,7 +108,7 @@ export function saveDevicesWateringSchedules(schedules, changed) {
               change: change,
               schedule: schedule,
               params: params,
-              result: result.data.schedules,
+              result: result.data.schedule,
             });
           },
           error => {
@@ -126,7 +126,7 @@ export function saveDevicesWateringSchedules(schedules, changed) {
               change: change,
               schedule: schedule,
               params: params,
-              result: result.data.schedules,
+              result: result.data.schedule,
             });
           },
           error => {

--- a/src/components/common/EditableTable.js
+++ b/src/components/common/EditableTable.js
@@ -97,8 +97,9 @@ export default class EditableTable extends React.Component {
           columns={this.props.columns}
           defaultPageSize={10}
           minRows={2}
-          defaultSorting={[{
-            id: 'Name',
+          sortable={false}
+          defaultSorted={[{
+            id: 'id',
             desc: false
           }]}
       />

--- a/src/js/Bastet.js
+++ b/src/js/Bastet.js
@@ -58,18 +58,18 @@ export default class Bastet {
     return this.callApi(this.get, url);
   }
 
-  createWateringsSchedule(device_id, data) {
-    var url = this.host + '/devices/waterings/' + device_id + '/schedules/';
+  createWateringsSchedule(deviceId, data) {
+    var url = this.host + '/devices/waterings/' + deviceId + '/schedules/';
     return this.callApi(this.post, url, {schedule: data});
   }
 
-  updateWateringsSchedule(device_id, schedule_id, data) {
-    var url = this.host + '/devices/waterings/' + device_id + '/schedules/' + schedule_id;
+  updateWateringsSchedule(deviceId, data) {
+    var url = this.host + '/devices/waterings/' + deviceId + '/schedules/' + data.id;
     return this.callApi(this.put, url, {schedule: data});
   }
 
-  deleteWateringsSchedule(device_id, schedule_id) {
-    var url = this.host + '/devices/waterings/' + device_id + '/schedules/' + schedule_id;
+  deleteWateringsSchedule(deviceId, data) {
+    var url = this.host + '/devices/waterings/' + deviceId + '/schedules/' + data.id;
     return this.callApi(this.delete, url);
   }
 

--- a/src/reducers/devicesWatering.js
+++ b/src/reducers/devicesWatering.js
@@ -78,53 +78,57 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
 
     case DevicesWatering.SAVE_SCHEDULES_SUCCESS:
       // スケジュール情報の保存完了
-      return state.set('changed', Map({}));
+      return state;
 
     case DevicesWatering.SAVE_SCHEDULES_FAILURE:
       // スケジュール情報の保存失敗
+      console.log(action.error);
       return state;
 
     case DevicesWatering.POST_SCHEDULES_REQUEST:
-      // スケジュール情報の保存開始
+      // スケジュール情報のpost開始
       return state;
 
     case DevicesWatering.POST_SCHEDULES_SUCCESS:
-      // スケジュール情報の保存完了
-      // TODO postした結果払い出されたIDを設定する
-      // const list = this.state.schedules;
-      // const index = GtbUtils.findIndex(list, 'id', value.id);
-      // this.logger.info(data, value, index, list)
-      // list[index]['id'] = data.data.schedule.id;
-      // this.setState({schedules: list});
-      // return;
-      return state;
+      // スケジュール情報のpost完了
+
+      // postした結果払い出されたIDを設定する
+      // 変更が完了した情報を削除する
+      var postedIndex = GtbUtils.findIndex(state.get('schedules').toJS(), 'id', action.params.id);
+      return state.withMutations(map => { map
+        .setIn(['schedules', postedIndex, 'id'], action.result.id)
+        .deleteIn(['changed', action.params.id])
+        ;
+      });
 
     case DevicesWatering.POST_SCHEDULES_FAILURE:
-      // スケジュール情報の保存失敗
+      // スケジュール情報のpost失敗
       return state;
 
     case DevicesWatering.PUT_SCHEDULES_REQUEST:
-      // スケジュール情報の保存開始
+      // スケジュール情報のput開始
       return state;
 
     case DevicesWatering.PUT_SCHEDULES_SUCCESS:
-      // スケジュール情報の保存完了
-      return state;
+      // スケジュール情報のput完了
+      // 変更が完了した情報を削除する
+      return state.deleteIn(['changed', action.params.id]);
 
     case DevicesWatering.PUT_SCHEDULES_FAILURE:
-      // スケジュール情報の保存失敗
+      // スケジュール情報のput失敗
       return state;
 
     case DevicesWatering.DELETE_SCHEDULES_REQUEST:
-      // スケジュール情報の保存開始
+      // スケジュール情報のdelete開始
       return state;
 
     case DevicesWatering.DELETE_SCHEDULES_SUCCESS:
-      // スケジュール情報の保存完了
-      return state;
+      // スケジュール情報のdelete完了
+      // 変更が完了した情報を削除する
+      return state.deleteIn(['changed', action.params.id]);
 
     case DevicesWatering.DELETE_SCHEDULES_FAILURE:
-      // スケジュール情報の保存失敗
+      // スケジュール情報のdelete失敗
       return state;
 
     case DevicesWatering.ADD_SCHEDULE:

--- a/src/reducers/devicesWatering.js
+++ b/src/reducers/devicesWatering.js
@@ -181,17 +181,6 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
         ;
       });
 
-      // // 変更対象スケジュールObjectをまるごと保持するタイプ
-      // return state.withMutations(map => { map
-      //   .setIn(['schedules', updateIndex, action.column], action.value);
-      //   if (!map.get('changed').has(action.id)) {
-      //     // 対象行初回変更時はマップごとコピーする
-      //     map.setIn(['changed', action.id], state.getIn(['schedules', updateIndex]));
-      //   }
-      //   map.setIn(['changed', action.id, action.column], action.value);
-      //   ;
-      // });
-
     default:
       return state;
   }


### PR DESCRIPTION
### 各APIコール時に、Bastetに反映された変更箇所をクライアントに反映する
1. post時に、払い出されたidを画面に反映
1. post/put/delete時に、成功した変更情報をクライアントから削除

### actionをスリムに
### テーブルソート時にバグっていた部分を修正（ソートできないようにした。そのうちソートできるようにしたい）