### PR TITLE
Feature/editable table/fix sorting when edited

### DIFF
--- a/src/components/DevicesWateringSummary.js
+++ b/src/components/DevicesWateringSummary.js
@@ -32,7 +32,7 @@ export default class DevicesWateringSummary extends Component {
 
   render() {
     // TODO nameを変更できるようにする
-    this.logger.log(this.props)
+    // this.logger.log(this.props)
     return (
       <div>
         <div>

--- a/src/components/DevicesWateringTab.js
+++ b/src/components/DevicesWateringTab.js
@@ -11,7 +11,7 @@ export default class DevicesWateringTab extends Component {
 
     this.state = {
       deviceId: '',
-      activeTab: 'operationalRecords',
+      activeTab: 'settingSchedules',
     };
 
     this.logger = new Logger({prefix: 'DevicesWateringTab'});

--- a/src/components/DevicesWateringTab.js
+++ b/src/components/DevicesWateringTab.js
@@ -11,7 +11,7 @@ export default class DevicesWateringTab extends Component {
 
     this.state = {
       deviceId: '',
-      activeTab: 'settingSchedules',
+      activeTab: 'operationalRecords',
     };
 
     this.logger = new Logger({prefix: 'DevicesWateringTab'});

--- a/src/components/common/EditableTable.js
+++ b/src/components/common/EditableTable.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Input } from 'semantic-ui-react';
+import { Button, Input, Checkbox } from 'semantic-ui-react';
 import ReactTable from 'react-table'
 import 'react-table/react-table.css'
 import Logger from '../../js/Logger'
@@ -11,18 +11,152 @@ export default class EditableTable extends React.Component {
    */
   constructor(props) {
     super(props);
+    this.state = {
+      // enableSort: true,
+      // defaultSortMethod: this.enableSortMethod(),
+      sorted: props.defaultSorted
+                ? this.props.defaultSorted
+                : [{id: 'id', desc: false}],
+      sortable: true,
+    };
+
     this.logger = new Logger({prefix: 'EditableTable'});
     this.update = this.update.bind(this);
+    this.debug = this.debug.bind(this);
+    this.onSortedChange = this.onSortedChange.bind(this);
+    // this.toggleEnableSort = this.toggleEnableSort.bind(this);
+    this.disableSort = this.disableSort.bind(this);
+    this.enableSort = this.enableSort.bind(this);
+    this.setSortable = this.setSortable.bind(this);
+    this.sortable = this.sortable.bind(this);
+    this.customSortMethod = this.customSortMethod.bind(this);
   }
 
   update(event, data, row, args) {
-    // this.logger.info('updated',
-    //   'event', event,
-    //   'data', data,
-    //   'row', row,
-    //   'args', args,
-    //   'props', this.props,
-    //   'state', this.state);
+    this.logger.info('updated',
+      'event', event,
+      'data', data,
+      'row', row,
+      'args', args,
+      'props', this.props,
+      'state', this.state);
+  }
+
+  debug(args) {
+    this.logger.info('debug',
+      'args', args,
+      'props', this.props,
+      'state', this.state);
+  }
+
+  disableSort() {
+    this.logger.info('disableSort',
+      'props', this.props,
+      'state', this.state);
+    this.setSortable(false);
+  }
+
+  enableSort() {
+    this.setSortable(true);
+  }
+
+
+  // toggleEnableSort() {
+  //   var enableSort = !this.state.enableSort;
+  //   var defaultSortMethod = this.state.enableSort
+  //     ? this.enableSortMethod()
+  //     : this.disableSortMethod()
+  //     ;
+
+  //   this.logger.log('切り替え', enableSort, defaultSortMethod);
+  //   this.setState({
+  //     enableSort: enableSort,
+  //     defaultSortMethod: defaultSortMethod,
+  //   });
+  // }
+
+  setSortable(enable) {
+    // var defaultSortMethod = enable
+    //   ? this.enableSortMethod()
+    //   : this.disableSortMethod()
+    //   ;
+
+    var backSorted = [];
+    var sorted = this.state.backSorted;
+    if (!enable) {
+      backSorted = this.state.sorted;
+      sorted = [{id: '_viewIndex', desc: false}];
+    }
+
+
+    this.setState({
+      sortable: enable,
+      sorted: sorted,
+      backSorted: backSorted,
+      // defaultSortMethod: defaultSortMethod,
+    });
+  }
+
+
+  onSortedChange(newSorted, column, shiftKey) {
+    this.logger.log(this.state.sorted, '->', newSorted);
+    this.setState({
+      sorted: newSorted,
+      sortable: true,
+    });
+  }
+
+  customSortMethod(a, b, desc, a1, a2) {
+    a = (a === null || a === undefined) ? -Infinity : a
+    b = (b === null || b === undefined) ? -Infinity : b
+    a = a === 'string' ? a.toLowerCase() : a
+    b = b === 'string' ? b.toLowerCase() : b
+    // if ((typeof a === 'string') && (a.match(/Schedule/gi))) {
+    if ((typeof a === 'string')) {
+      console.log("called customSortMethod", a, b, desc, this.state.sortable, a1, a2);
+      // this.debug('bbb');
+    }
+
+    if (!this.state.sortable) {
+      console.log("called customSortMethod returned 0");
+      return 0;
+    }
+
+    if (a > b) {
+      return 1;
+    }
+    if (a < b) {
+      return -1;
+    }
+    return 0;
+  }
+
+  enableSortMethod() {
+    return (a, b, desc) => {
+      a = (a === null || a === undefined) ? -Infinity : a
+      b = (b === null || b === undefined) ? -Infinity : b
+      a = a === 'string' ? a.toLowerCase() : a
+      b = b === 'string' ? b.toLowerCase() : b
+      console.log("called enable", a, b, desc, this.state.sortable)
+      if (a > b) {
+        return 1
+      }
+      if (a < b) {
+        return -1
+      }
+      return 0
+    }
+  }
+
+  disableSortMethod() {
+    return (a, b, desc) => {
+      a = (a === null || a === undefined) ? -Infinity : a
+      b = (b === null || b === undefined) ? -Infinity : b
+      a = a === 'string' ? a.toLowerCase() : a
+      b = b === 'string' ? b.toLowerCase() : b
+      console.log("called disable", a, b, desc)
+      return 0
+    }
   }
 
   /**
@@ -103,26 +237,37 @@ export default class EditableTable extends React.Component {
     })
   }
 
+  sortable() {
+    // ソート可否ボタンクリック時の処理
+    this.logger.log(this.state.sortable, '->', !this.state.sortable);
+    this.setSortable(!this.state.sortable)
+    // this.setState({sortable: !this.state.sortable});
+  }
+
   /**
    * TODO テーブル描画 必要に応じて外部から設定できるように修正していく
    */
   render() {
     // this.logger.log('render', this.props, this.state);
     return (
-      <ReactTable
-          className="-striped -highlight"
-          data={this.props.data}
-          columns={this.props.columns}
-          loading={this.props.loading}
-          defaultPageSize={12}
-          minRows={3}
-          sortable={this.props.sortable}
-          defaultSorted={
-            this.props.defaultSorted
-              ? this.props.defaultSorted
-              : [{id: 'id', desc: false}]
-          }
-      />
+      <div>
+        <Button as='a' onClick={this.debug}>debug</Button>
+        <Button as='a' onClick={this.sortable}>ソート切り替え</Button>
+        <Checkbox toggle checked={this.state.sortable} onClick={this.debug} label='Sortable' />
+        <ReactTable
+            className="-striped -highlight"
+            defaultSortMethod={this.customSortMethod}
+            data={this.props.data}
+            columns={this.props.columns}
+            loading={this.props.loading}
+            defaultPageSize={12}
+            minRows={3}
+            sortable={true}
+            defaultSorted={[]}
+            sorted={this.state.sorted}
+            onSortedChange={this.onSortedChange}
+        />
+      </div>
     );
   }
 

--- a/src/components/common/EditableTable.js
+++ b/src/components/common/EditableTable.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Input, Checkbox } from 'semantic-ui-react';
+import { Button, Input } from 'semantic-ui-react';
 import ReactTable from 'react-table'
 import 'react-table/react-table.css'
 import Logger from '../../js/Logger'
@@ -11,152 +11,18 @@ export default class EditableTable extends React.Component {
    */
   constructor(props) {
     super(props);
-    this.state = {
-      // enableSort: true,
-      // defaultSortMethod: this.enableSortMethod(),
-      sorted: props.defaultSorted
-                ? this.props.defaultSorted
-                : [{id: 'id', desc: false}],
-      sortable: true,
-    };
-
     this.logger = new Logger({prefix: 'EditableTable'});
     this.update = this.update.bind(this);
-    this.debug = this.debug.bind(this);
-    this.onSortedChange = this.onSortedChange.bind(this);
-    // this.toggleEnableSort = this.toggleEnableSort.bind(this);
-    this.disableSort = this.disableSort.bind(this);
-    this.enableSort = this.enableSort.bind(this);
-    this.setSortable = this.setSortable.bind(this);
-    this.sortable = this.sortable.bind(this);
-    this.customSortMethod = this.customSortMethod.bind(this);
   }
 
   update(event, data, row, args) {
-    this.logger.info('updated',
-      'event', event,
-      'data', data,
-      'row', row,
-      'args', args,
-      'props', this.props,
-      'state', this.state);
-  }
-
-  debug(args) {
-    this.logger.info('debug',
-      'args', args,
-      'props', this.props,
-      'state', this.state);
-  }
-
-  disableSort() {
-    this.logger.info('disableSort',
-      'props', this.props,
-      'state', this.state);
-    this.setSortable(false);
-  }
-
-  enableSort() {
-    this.setSortable(true);
-  }
-
-
-  // toggleEnableSort() {
-  //   var enableSort = !this.state.enableSort;
-  //   var defaultSortMethod = this.state.enableSort
-  //     ? this.enableSortMethod()
-  //     : this.disableSortMethod()
-  //     ;
-
-  //   this.logger.log('切り替え', enableSort, defaultSortMethod);
-  //   this.setState({
-  //     enableSort: enableSort,
-  //     defaultSortMethod: defaultSortMethod,
-  //   });
-  // }
-
-  setSortable(enable) {
-    // var defaultSortMethod = enable
-    //   ? this.enableSortMethod()
-    //   : this.disableSortMethod()
-    //   ;
-
-    var backSorted = [];
-    var sorted = this.state.backSorted;
-    if (!enable) {
-      backSorted = this.state.sorted;
-      sorted = [{id: '_viewIndex', desc: false}];
-    }
-
-
-    this.setState({
-      sortable: enable,
-      sorted: sorted,
-      backSorted: backSorted,
-      // defaultSortMethod: defaultSortMethod,
-    });
-  }
-
-
-  onSortedChange(newSorted, column, shiftKey) {
-    this.logger.log(this.state.sorted, '->', newSorted);
-    this.setState({
-      sorted: newSorted,
-      sortable: true,
-    });
-  }
-
-  customSortMethod(a, b, desc, a1, a2) {
-    a = (a === null || a === undefined) ? -Infinity : a
-    b = (b === null || b === undefined) ? -Infinity : b
-    a = a === 'string' ? a.toLowerCase() : a
-    b = b === 'string' ? b.toLowerCase() : b
-    // if ((typeof a === 'string') && (a.match(/Schedule/gi))) {
-    if ((typeof a === 'string')) {
-      console.log("called customSortMethod", a, b, desc, this.state.sortable, a1, a2);
-      // this.debug('bbb');
-    }
-
-    if (!this.state.sortable) {
-      console.log("called customSortMethod returned 0");
-      return 0;
-    }
-
-    if (a > b) {
-      return 1;
-    }
-    if (a < b) {
-      return -1;
-    }
-    return 0;
-  }
-
-  enableSortMethod() {
-    return (a, b, desc) => {
-      a = (a === null || a === undefined) ? -Infinity : a
-      b = (b === null || b === undefined) ? -Infinity : b
-      a = a === 'string' ? a.toLowerCase() : a
-      b = b === 'string' ? b.toLowerCase() : b
-      console.log("called enable", a, b, desc, this.state.sortable)
-      if (a > b) {
-        return 1
-      }
-      if (a < b) {
-        return -1
-      }
-      return 0
-    }
-  }
-
-  disableSortMethod() {
-    return (a, b, desc) => {
-      a = (a === null || a === undefined) ? -Infinity : a
-      b = (b === null || b === undefined) ? -Infinity : b
-      a = a === 'string' ? a.toLowerCase() : a
-      b = b === 'string' ? b.toLowerCase() : b
-      console.log("called disable", a, b, desc)
-      return 0
-    }
+    // this.logger.info('updated',
+    //   'event', event,
+    //   'data', data,
+    //   'row', row,
+    //   'args', args,
+    //   'props', this.props,
+    //   'state', this.state);
   }
 
   /**
@@ -237,13 +103,6 @@ export default class EditableTable extends React.Component {
     })
   }
 
-  sortable() {
-    // ソート可否ボタンクリック時の処理
-    this.logger.log(this.state.sortable, '->', !this.state.sortable);
-    this.setSortable(!this.state.sortable)
-    // this.setState({sortable: !this.state.sortable});
-  }
-
   /**
    * TODO テーブル描画 必要に応じて外部から設定できるように修正していく
    */
@@ -251,9 +110,6 @@ export default class EditableTable extends React.Component {
     // this.logger.log('render', this.props, this.state);
     return (
       <div>
-        <Button as='a' onClick={this.debug}>debug</Button>
-        <Button as='a' onClick={this.sortable}>ソート切り替え</Button>
-        <Checkbox toggle checked={this.state.sortable} onClick={this.debug} label='Sortable' />
         <ReactTable
             className="-striped -highlight"
             defaultSortMethod={this.customSortMethod}
@@ -262,10 +118,10 @@ export default class EditableTable extends React.Component {
             loading={this.props.loading}
             defaultPageSize={12}
             minRows={3}
-            sortable={true}
-            defaultSorted={[]}
-            sorted={this.state.sorted}
-            onSortedChange={this.onSortedChange}
+            sortable={this.props.sortable}
+            defaultSorted={this.props.defaultSorted
+                ? this.props.defaultSorted
+                : [{id: 'id', desc: false}]}
         />
       </div>
     );

--- a/src/containers/DevicesWateringOperationalRecords.js
+++ b/src/containers/DevicesWateringOperationalRecords.js
@@ -13,7 +13,7 @@ class DevicesWateringOperationalRecords extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextState) {
-    this.logger.log('componentWillReceiveProps', 'nextProps', nextProps);
+    // this.logger.log('componentWillReceiveProps', 'nextProps', nextProps);
   }
 
   render() {

--- a/src/containers/DevicesWateringSchedules.js
+++ b/src/containers/DevicesWateringSchedules.js
@@ -11,7 +11,6 @@ import * as Actions from '../actions/devicesWatering';
 class DevicesWateringSchedules extends React.Component {
   constructor(props) {
     super(props);
-
     this.logger = new Logger({prefix: 'DevicesWateringsSchedules'});
 
     this.update = this.update.bind(this);

--- a/src/containers/DevicesWateringSchedules.js
+++ b/src/containers/DevicesWateringSchedules.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button } from 'semantic-ui-react';
+import { Button, Checkbox } from 'semantic-ui-react';
 import EditableTable from '../components/common/EditableTable'
 import Logger from '../js/Logger'
 import Formatter from '../js/Formatter'
@@ -11,6 +11,10 @@ import * as Actions from '../actions/devicesWatering';
 class DevicesWateringSchedules extends React.Component {
   constructor(props) {
     super(props);
+
+    // this.state = {
+    // };
+
     this.logger = new Logger({prefix: 'DevicesWateringsSchedules'});
 
     this.update = this.update.bind(this);
@@ -23,15 +27,17 @@ class DevicesWateringSchedules extends React.Component {
 
   update(event, data, row, args) {
     // セル入力時の処理
+    this.refs.editableTable.disableSort();
     this.props.actions.updateDevicesWateringSchedule(row.row.id, row.column.id, data.value);
     this.setState({saveButtonDisabled: false});
 
-    // this.logger.info('updated',
-    //   'event', event,
-    //   'data', data,
-    //   'row', row,
-    //   'args', args,
-    //   'props', this.props,
+    this.logger.info('updated',
+      'event', event,
+      'data', data,
+      'row', row,
+      'args', args,
+      'props', this.props,
+      )
 
     // this.props.deviceWateringsSchedules[0].amount = 'aaa';
 
@@ -128,7 +134,9 @@ class DevicesWateringSchedules extends React.Component {
           data={this.props.devicesWateringSchedules}
           columns={columns}
           loading={this.props.progress}
-          sortable={false}
+          defaultSorted={[{id: 'name', desc: false}]}
+          defaultSorted={[]}
+          ref='editableTable'
         />
 
       </div>

--- a/src/containers/DevicesWateringSchedules.js
+++ b/src/containers/DevicesWateringSchedules.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Checkbox } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 import EditableTable from '../components/common/EditableTable'
 import Logger from '../js/Logger'
 import Formatter from '../js/Formatter'
@@ -11,9 +11,6 @@ import * as Actions from '../actions/devicesWatering';
 class DevicesWateringSchedules extends React.Component {
   constructor(props) {
     super(props);
-
-    // this.state = {
-    // };
 
     this.logger = new Logger({prefix: 'DevicesWateringsSchedules'});
 
@@ -27,17 +24,16 @@ class DevicesWateringSchedules extends React.Component {
 
   update(event, data, row, args) {
     // セル入力時の処理
-    this.refs.editableTable.disableSort();
     this.props.actions.updateDevicesWateringSchedule(row.row.id, row.column.id, data.value);
     this.setState({saveButtonDisabled: false});
 
-    this.logger.info('updated',
-      'event', event,
-      'data', data,
-      'row', row,
-      'args', args,
-      'props', this.props,
-      )
+    // this.logger.info('updated',
+    //   'event', event,
+    //   'data', data,
+    //   'row', row,
+    //   'args', args,
+    //   'props', this.props,
+    //   )
 
     // this.props.deviceWateringsSchedules[0].amount = 'aaa';
 
@@ -135,8 +131,6 @@ class DevicesWateringSchedules extends React.Component {
           columns={columns}
           loading={this.props.progress}
           defaultSorted={[{id: 'name', desc: false}]}
-          defaultSorted={[]}
-          ref='editableTable'
         />
 
       </div>

--- a/src/reducers/devicesSystemLog.js
+++ b/src/reducers/devicesSystemLog.js
@@ -11,8 +11,8 @@ const initialDevicesSystemLog = Map({
 });
 
 const deviceSystemLog = (state = initialDevicesSystemLog, action) => {
-  _logger.info('state :', state.toJS());
-  _logger.info('action :', action);
+  // _logger.info('state :', state.toJS());
+  // _logger.info('action :', action);
 
   switch (action.type) {
     case DevicesSystemLog.LOAD_REQUEST:

--- a/src/reducers/devicesSystemLog.js
+++ b/src/reducers/devicesSystemLog.js
@@ -1,9 +1,9 @@
 import { List, Map, fromJS } from 'immutable';
 import { DevicesSystemLog } from '../constants/devicesSystemLog';
 import GtbUtils from '../js/GtbUtils'
-import Logger from '../js/Logger'
+// import Logger from '../js/Logger'
 
-const _logger = new Logger({prefix: 'devicesSystemLog'});
+// const _logger = new Logger({prefix: 'devicesSystemLog'});
 
 const initialDevicesSystemLog = Map({
   'list': List([]),

--- a/src/reducers/devicesWatering.js
+++ b/src/reducers/devicesWatering.js
@@ -86,7 +86,11 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
     case DevicesWatering.LOAD_SCHEDULES_SUCCESS:
       // スケジュール情報の取得完了
       return state.withMutations(map => { map
-        .set('schedules', fromJS(action.schedules))
+        .set('schedules', fromJS(action.schedules).sort((a, b) => {
+          if( a < b ) return -1;
+          if( a > b ) return 1;
+          return 0;
+        }))
         .set('changed', Map({}))
         .set('progress', false)
         ;


### PR DESCRIPTION
### 修正内容
スケジュールの初期ソートをnameに変更。
nameをユーザが修正した場合、それに即時にソートが適用されてしまう問題点は**未修正**。
**とりあえずユーザーに気をつけてもらう。** という糞仕様で進む。

### 経緯
スケジュールを、現状、idでソートしてたのですが、追加するidが連番ではなくなってしまったので、「追加したスケジュールどこ行った？」ってなる。
流石にめちゃくちゃだったので、「好きな項目でソートできる。入力時にソートを一時停止する。」っていう修正を入れたかった。
が、どうしてももうまく行かなかったので、**とりあえず放棄**します。
頑張った感じは 871dc1c を参照。誰か助けて。