### PR TITLE
灌水実績にduration項目を追加

### DIFF
--- a/src/containers/DevicesWateringOperationalRecords.js
+++ b/src/containers/DevicesWateringOperationalRecords.js
@@ -35,6 +35,11 @@ class DevicesWateringOperationalRecords extends React.Component {
         width: 180,
         Cell: EditableTable.createNormalCell()
       }, {
+        Header: 'Duration',
+        accessor: 'duration',
+        width: 120,
+        Cell: EditableTable.createNormalCell()
+      }, {
         Header: 'Amount',
         accessor: 'amount',
         width: 120,

--- a/src/reducers/devicesWatering.js
+++ b/src/reducers/devicesWatering.js
@@ -216,11 +216,14 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
     case DevicesWatering.LOAD_OPERATIONAL_RECORDS_SUCCESS:
       // 実績の取得完了
       let operationalRecords = action.operationalRecords.map((value) => {
+          let started_at = new Date(value["started_at"]);
+          let ended_at = new Date(value["ended_at"]);
           return {
             // key: value["key"],
             id: value["id"],
-            started_at: GtbUtils.dateString(new Date(value["started_at"])),
-            ended_at:   GtbUtils.dateString(new Date(value["ended_at"])),
+            started_at: GtbUtils.dateString(started_at),
+            ended_at:   GtbUtils.dateString(ended_at),
+            duration:   GtbUtils.round((ended_at - started_at) / 1000),
             amount: value["amount"],
             is_manual: value["is_manual"],
           };


### PR DESCRIPTION
灌水実績にduration項目を追加した。
開始終了だけだと、ぱっとみ何秒流れたかわからなかったため。

![2018-01-01 10 51 27](https://user-images.githubusercontent.com/1407926/34465091-c4e3462a-eee1-11e7-9bdd-2645a2d69e76.png)
