### PR TITLE
各デバイスで共通な部分を汎化

### DIFF
--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -1,0 +1,57 @@
+import {Device} from '../constants/device';
+import {loadWateringInformations} from './devicesWatering';
+import {loadPyranometerInformations} from './devicesPyranometer';
+import GtbUtils from '../js/GtbUtils'
+import Bastet from '../js/Bastet'
+
+export function loadDevices(args = {}) {
+  // TODO argsにはOrganizationIdなどを予定
+  return function(dispatch) {
+    dispatch({ type: Device.LOAD_REQUEST });
+    let bastet = new Bastet();
+    return bastet.getDevices().then(
+      result => {
+        dispatch({ type: Device.LOAD_SUCCESS, list: result });
+      },
+      error => {
+        dispatch({ type: Device.LOAD_FAILURE, list: error })
+      }
+    );
+  }
+};
+
+export function selectApp(app) {
+  // Appの切り替え
+  return function(dispatch) {
+    dispatch({ type: Device.APP, app: app });
+  }
+}
+
+export function selectDevice(deviceId, devices, lastDeviceId) {
+  let device = GtbUtils.find(devices, 'id', deviceId);
+  // console.log('select: device', device);
+  if (deviceId === lastDeviceId) {
+    return function(dispatch) {
+      dispatch({ type: Device.SELECT, id: deviceId, device: device, lastId: lastDeviceId });
+    }
+
+  } else {
+    // デバイスIDが変更された場合は再読込も行う
+    // TODO このハンドリングは別の場所で行うべきかもしれない
+    // TODO 現状、デバイスIDが変更される度にBastetから取得することになるが、タンクすべきかもしれない
+    return function(dispatch) {
+      dispatch({ type: Device.SELECT, id: deviceId, device: device, lastId: lastDeviceId });
+      switch (device.device_type) {
+        case 'watering':
+          dispatch(loadWateringInformations(device));
+          break;
+        case 'pyranometer':
+          dispatch(loadPyranometerInformations(device));
+          break;
+        default:
+          console.error('error: unknown device_type', device.device_type);
+          break;
+      }
+    }
+  }
+};

--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -51,30 +51,24 @@ export function selectApp(app) {
   }
 }
 
-export function selectDevice(deviceId, devices, lastDeviceId) {
+export function selectDevice(deviceId, devices) {
   return function(dispatch) {
-    return new Promise((re) => {
+    return new Promise(() => {
+      // デバイスを選択し情報の再読込
+      // TODO このハンドリングは別の場所で行うべきかもしれない
+      // TODO 現状、デバイスIDが変更される度にBastetから取得することになるが、タンクすべきかもしれない
       let device = GtbUtils.find(devices, 'id', deviceId);
-      // console.log('select: device', device);
-      if (deviceId === lastDeviceId) {
-        dispatch({ type: Device.SELECT, id: deviceId, device: device, lastId: lastDeviceId });
-
-      } else {
-        // デバイスIDが変更された場合は再読込も行う
-        // TODO このハンドリングは別の場所で行うべきかもしれない
-        // TODO 現状、デバイスIDが変更される度にBastetから取得することになるが、タンクすべきかもしれない
-        dispatch({ type: Device.SELECT, id: deviceId, device: device, lastId: lastDeviceId });
-        switch (device.device_type) {
-          case 'watering':
-            dispatch(loadWateringInformations(device));
-            break;
-          case 'pyranometer':
-            dispatch(loadPyranometerInformations(device));
-            break;
-          default:
-            console.error('error: unknown device_type', device.device_type);
-            break;
-        }
+      dispatch({ type: Device.SELECT, id: deviceId });
+      switch (device.device_type) {
+        case 'watering':
+          dispatch(loadWateringInformations(device));
+          break;
+        case 'pyranometer':
+          dispatch(loadPyranometerInformations(device));
+          break;
+        default:
+          console.error('error: unknown device_type', device.device_type);
+          break;
       }
     });
   }

--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -4,6 +4,11 @@ import {loadPyranometerInformations} from './devicesPyranometer';
 import GtbUtils from '../js/GtbUtils'
 import Bastet from '../js/Bastet'
 
+/**
+ * deviceをloadする
+ * @param  {Object} args [description]
+ * @return {[type]}      [description]
+ */
 export function loadDevices(args = {}) {
   // TODO argsにはOrganizationIdなどを予定
   return function(dispatch) {
@@ -20,6 +25,13 @@ export function loadDevices(args = {}) {
   }
 };
 
+/**
+ * 現在各appで選択状態になっているdeviceの詳細情報をloadする
+ * load後に呼び出されることを想定
+ * @param  {[type]} app          [description]
+ * @param  {[type]} typeSelected [description]
+ * @return {[type]}              [description]
+ */
 export function initialLoadDeviceInformations(app, typeSelected) {
   return function(dispatch) {
     let promises = [];
@@ -44,13 +56,23 @@ export function initialLoadDeviceInformations(app, typeSelected) {
   }
 }
 
+/**
+ * appを選択する
+ * @param  {[type]} app [description]
+ * @return {[type]}     [description]
+ */
 export function selectApp(app) {
-  // Appの切り替え
   return function(dispatch) {
     dispatch({ type: Device.APP, app: app });
   }
 }
 
+/**
+ * deviceを選択する
+ * @param  {[type]} deviceId [description]
+ * @param  {[type]} devices  [description]
+ * @return {[type]}          [description]
+ */
 export function selectDevice(deviceId, devices) {
   return function(dispatch) {
     return new Promise(() => {

--- a/src/actions/devicesPyranometer.js
+++ b/src/actions/devicesPyranometer.js
@@ -1,44 +1,10 @@
 import {DevicesPyranometer} from '../constants/devicesPyranometer';
 import Bastet from '../js/Bastet'
 
-export function loadDevicesPyranometers() {
+export function loadPyranometerInformations(device) {
   return function(dispatch) {
-    dispatch({ type: DevicesPyranometer.LOAD_REQUEST });
-
-    let bastet = new Bastet();
-    return bastet.getDevicesPyranometers().then(
-      result => {
-        dispatch({ type: DevicesPyranometer.LOAD_SUCCESS, list: result });
-
-        if (0 !== result.length) {
-          // データが存在する場合は先頭要素を選択状態とする
-          dispatch(selectDevicesPyranometer(result[0].id));
-        }
-      },
-      error => {
-        // DEBUG エラー時にダミーデータを使用する場合
-        // これは将来的に削除されるか、もっとスマートな形で実装される
-        dispatch({ type: DevicesPyranometer.LOAD_SUCCESS, list: _load()})
-        // dispatch({ type: DevicesPyranometer.LOAD_FAILURE, list: error })
-      }
-    );
-  }
-};
-
-export function selectDevicesPyranometer(deviceId, lastDeviceId) {
-  if (deviceId === lastDeviceId) {
-    return function(dispatch) {
-      dispatch({ type: DevicesPyranometer.SELECT, id: deviceId });
-    }
-
-  } else {
-    // デバイスIDが変更された場合は実績の再読込も行う
-    // TODO このハンドリングは別の場所で行うべきかもしれない
-    // TODO 現状、デバイスIDが変更される度にスケジュール情報をBastetから取得することになるが、タンクすべきかもしれない
-    return function(dispatch) {
-      dispatch({ type: DevicesPyranometer.SELECT, id: deviceId });
-      dispatch(loadDevicesPyranometerSensingRecords(deviceId));
-    }
+    dispatch({ type: DevicesPyranometer.SELECT, device: device });
+    dispatch(loadDevicesPyranometerSensingRecords(device.id));
   }
 };
 
@@ -49,31 +15,9 @@ export function loadDevicesPyranometerSensingRecords(deviceId) {
     return bastet.getPyranometersSensingRecords(deviceId).then(
       result => dispatch({ type: DevicesPyranometer.LOAD_SENSING_RECORDS_SUCCESS, sensingRecords: result.data }),
       error => {
-        // DEBUG エラー時にダミーデータを使用する場合
-        // これは将来的に削除されるか、もっとスマートな形で実装される
-        dispatch({ type: DevicesPyranometer.LOAD_SENSING_RECORDS_SUCCESS, sensingRecords: _loadSensingRecords()})
-        // dispatch({ type: DevicesPyranometer.LOAD_SCHEDULES_FAILURE, schedules: error })
+        dispatch({ type: DevicesPyranometer.LOAD_SCHEDULES_FAILURE, schedules: error })
       }
     );
   }
 };
 
-/**
- * FOR DEBUG
- */
-const _load = () => {
-  return [
-    { key: "1", id: 1, name: "device 1",},
-    { key: "2", id: 2, name: "device 2",},
-  ];
-}
-
-/**
- * FOR DEBUG
- */
-const _loadSensingRecords = (deviceId) => {
-  return [
-    { id: deviceId + "1", sensed_at: "07:01:00", measurement: "100", },
-    { id: deviceId + "2", sensed_at: "08:01:00", measurement: "200", },
-  ];
-}

--- a/src/actions/devicesPyranometer.js
+++ b/src/actions/devicesPyranometer.js
@@ -4,7 +4,7 @@ import Bastet from '../js/Bastet'
 export function loadPyranometerInformations(device) {
   return function(dispatch) {
     dispatch({ type: DevicesPyranometer.SELECT, device: device });
-    dispatch(loadDevicesPyranometerSensingRecords(device.id));
+    return dispatch(loadDevicesPyranometerSensingRecords(device.id));
   }
 };
 

--- a/src/actions/devicesWatering.js
+++ b/src/actions/devicesWatering.js
@@ -3,45 +3,11 @@ import {DevicesWatering} from '../constants/devicesWatering';
 import GtbUtils from '../js/GtbUtils'
 import Bastet from '../js/Bastet'
 
-export function loadDevicesWaterings() {
+export function loadWateringInformations(device) {
   return function(dispatch) {
-    dispatch({ type: DevicesWatering.LOAD_REQUEST });
-
-    let bastet = new Bastet();
-    return bastet.getDevicesWaterings().then(
-      result => {
-        dispatch({ type: DevicesWatering.LOAD_SUCCESS, list: result });
-
-        if (0 !== result.length) {
-          // データが存在する場合は先頭要素を選択状態とする
-          dispatch(selectDevicesWatering(result[0].id));
-        }
-      },
-      error => {
-        // DEBUG エラー時にダミーデータを使用する場合
-        // これは将来的に削除されるか、もっとスマートな形で実装される
-        dispatch({ type: DevicesWatering.LOAD_SUCCESS, list: _load()})
-        // dispatch({ type: DevicesWatering.LOAD_FAILURE, list: error })
-      }
-    );
-  }
-};
-
-export function selectDevicesWatering(deviceId, lastDeviceId) {
-  if (deviceId === lastDeviceId) {
-    return function(dispatch) {
-      dispatch({ type: DevicesWatering.SELECT, id: deviceId });
-    }
-
-  } else {
-    // デバイスIDが変更された場合はスケジュール/実績の再読込も行う
-    // TODO このハンドリングは別の場所で行うべきかもしれない
-    // TODO 現状、デバイスIDが変更される度にスケジュール情報をBastetから取得することになるが、タンクすべきかもしれない
-    return function(dispatch) {
-      dispatch({ type: DevicesWatering.SELECT, id: deviceId });
-      dispatch(loadDevicesWateringSchedules(deviceId));
-      dispatch(loadDevicesWateringOperationalRecords(deviceId));
-    }
+    dispatch({ type: DevicesWatering.SELECT, device: device });
+    dispatch(loadDevicesWateringSchedules(device.id));
+    dispatch(loadDevicesWateringOperationalRecords(device.id));
   }
 };
 
@@ -52,10 +18,7 @@ export function loadDevicesWateringSchedules(deviceId) {
     return bastet.getWateringsSchedules(deviceId).then(
       result => dispatch({ type: DevicesWatering.LOAD_SCHEDULES_SUCCESS, schedules: result.data.schedules }),
       error => {
-        // DEBUG エラー時にダミーデータを使用する場合
-        // これは将来的に削除されるか、もっとスマートな形で実装される
-        dispatch({ type: DevicesWatering.LOAD_SCHEDULES_SUCCESS, schedules: _loadSchedules()})
-        // dispatch({ type: DevicesWatering.LOAD_SCHEDULES_FAILURE, schedules: error })
+        dispatch({ type: DevicesWatering.LOAD_SCHEDULES_FAILURE, schedules: error })
       }
     );
   }
@@ -65,10 +28,11 @@ function checkValid(changed) {
   let valid = true;
   Object.keys(changed).forEach((key) => {
     let change = changed[key];
-    if (change._errors) {
-      Object.keys(change._errors).forEach((column) => {
-        // console.log('check...', change._errors[column], null === change._errors[column]);
-        valid &= (null === change._errors[column]);
+    let errors = change._errors;
+    if (errors) {
+      Object.keys(errors).forEach((column) => {
+        let error = errors[column];
+        valid &= (null === error || undefined === error);
       });
     }
   });
@@ -79,7 +43,8 @@ export function saveDevicesWateringSchedules(schedules, changed) {
   return function(dispatch) {
 
     if (!checkValid(changed)) {
-      // TODO エラーメッセージ
+      // TODO エラーが存在するためBastetへの更新を行わない場合の画面表示メッセージ
+      console.log('check error', changed);
       return false;
     }
 
@@ -149,8 +114,11 @@ export function saveDevicesWateringSchedules(schedules, changed) {
   }
 };
 
-export function addDevicesWateringSchedule() {
-  return { type: DevicesWatering.ADD_SCHEDULE };
+export function addDevicesWateringSchedule(deviceId) {
+  return {
+    type: DevicesWatering.ADD_SCHEDULE,
+    deviceId: deviceId,
+  };
 };
 
 export function removeDevicesWateringSchedule(id) {
@@ -177,10 +145,7 @@ export function loadDevicesWateringOperationalRecords(deviceId) {
     return bastet.getWateringsOperationalRecords(deviceId).then(
       result => dispatch({ type: DevicesWatering.LOAD_OPERATIONAL_RECORDS_SUCCESS, operationalRecords: result.data }),
       error => {
-        // DEBUG エラー時にダミーデータを使用する場合
-        // これは将来的に削除されるか、もっとスマートな形で実装される
-        dispatch({ type: DevicesWatering.LOAD_OPERATIONAL_RECORDS_SUCCESS, operationalRecords: _loadOperationalRecords()})
-        // dispatch({ type: DevicesWatering.LOAD_SCHEDULES_FAILURE, schedules: error })
+        dispatch({ type: DevicesWatering.LOAD_SCHEDULES_FAILURE, schedules: error })
       }
     );
   }
@@ -224,32 +189,3 @@ const apiDevicesWateringSchedule = (
   );
 }
 
-/**
- * FOR DEBUG
- */
-const _load = () => {
-  return [
-    { key: "1", id: 1, name: "device 1",},
-    { key: "2", id: 2, name: "device 2",},
-  ];
-}
-
-/**
- * FOR DEBUG
- */
-const _loadSchedules = (deviceId) => {
-  return [
-    { id: deviceId + "1", name: deviceId + "schedules 1", start_at: "07:00:00", stop_at: "07:00:0" + deviceId, amount: "100", },
-    { id: deviceId + "2", name: deviceId + "schedules 2", start_at: "08:00:00", stop_at: "08:00:0" + deviceId, amount: "200", },
-  ];
-}
-
-/**
- * FOR DEBUG
- */
-const _loadOperationalRecords = (deviceId) => {
-  return [
-    { id: deviceId + "1", started_at: "07:01:00", ended_at: "07:01:0" + deviceId, amount: "100", is_manual: true , },
-    { id: deviceId + "2", started_at: "08:01:00", ended_at: "08:01:0" + deviceId, amount: "200", is_manual: false, },
-  ];
-}

--- a/src/actions/devicesWatering.js
+++ b/src/actions/devicesWatering.js
@@ -6,8 +6,10 @@ import Bastet from '../js/Bastet'
 export function loadWateringInformations(device) {
   return function(dispatch) {
     dispatch({ type: DevicesWatering.SELECT, device: device });
-    dispatch(loadDevicesWateringSchedules(device.id));
-    dispatch(loadDevicesWateringOperationalRecords(device.id));
+    var promises = [];
+    promises.push(dispatch(loadDevicesWateringSchedules(device.id)));
+    promises.push(dispatch(loadDevicesWateringOperationalRecords(device.id)));
+    return Promise.all(promises);
   }
 };
 

--- a/src/components/DeviceSettingTab.js
+++ b/src/components/DeviceSettingTab.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import Logger from '../js/Logger'
+
+export default class DeviceSettingTab extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeTab: props.activeTabKey,
+    };
+
+    this.logger = new Logger({prefix: 'DevicesWateringTab'});
+    this.createTabHeader = this.createTabHeader.bind(this);
+    this.createTabContent = this.createTabContent.bind(this);
+    this.onTabClick = this.onTabClick.bind(this);
+  }
+
+  onTabClick(key) {
+    // タブ変更
+    this.setState({activeTab: key});
+  }
+
+  createTabHeader(key, content) {
+    // タブヘッダの作成
+    return(
+      <a className={"item " + (this.state.activeTab === key ? "active" : "")}
+        key={key}
+        data-tab={key}
+        onClick={() => {this.onTabClick(key)}}
+      >
+        {content}
+      </a>
+      );
+  }
+
+  createTabContent(key, content) {
+    // タブコンテンツの作成
+    return (
+      <div className={"ui bottom attached tab segment " + (this.state.activeTab === key ? "active" : "")}
+        key={key}
+        data-tab={key}
+      >
+        {content}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="ui top attached tabular menu">
+          {this.props.tabs.map((tab) => {
+            return this.createTabHeader(tab.key, tab.title);
+          })}
+        </div>
+        {this.props.tabs.map((tab) => {
+          return this.createTabContent(
+            tab.key,
+            <tab.component
+              deviceId={this.props.deviceId}
+              device={this.props.device}
+              />
+            );
+          })}
+      </div>
+    );
+  }
+}

--- a/src/components/DevicesPyranometerTab.js
+++ b/src/components/DevicesPyranometerTab.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Logger from '../js/Logger'
+import DeviceSettingTab from './DeviceSettingTab'
 import DevicesSummary from '../containers/DevicesSummary'
 import DevicesPyranometerSensingRecords from '../containers/DevicesPyranometerSensingRecords'
 import DevicesSystemLogs from '../containers/DevicesSystemLogs'
@@ -7,71 +8,29 @@ import DevicesSystemLogs from '../containers/DevicesSystemLogs'
 export default class DevicesPyranometerTab extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      deviceId: '',
-      activeTab: 'sensingRecords',
-    };
-
     this.logger = new Logger({prefix: 'DevicesPyranometerTab'});
-    this.createTabHeader = this.createTabHeader.bind(this);
-    this.createTabContent = this.createTabContent.bind(this);
-    this.onTabClick = this.onTabClick.bind(this);
-  }
-
-  onTabClick(key) {
-    // タブ変更
-    this.setState({activeTab: key});
-  }
-
-  createTabHeader(key, content) {
-    // タブヘッダの作成
-    return(
-      <a className={"item " + (this.state.activeTab === key ? "active" : "")}
-        data-tab={key}
-        onClick={() => {this.onTabClick(key)}}
-      >
-        {content}
-      </a>
-      );
-  }
-
-  createTabContent(key, content) {
-    // タブコンテンツの作成
-    return (
-      <div className={"ui bottom attached tab segment " + (this.state.activeTab === key ? "active" : "")}
-        data-tab={key}
-      >
-        {content}
-      </div>
-    );
   }
 
   render() {
     return (
-      <div>
-        <div className="ui top attached tabular menu">
-          {this.createTabHeader("settingBasic", "基本設定")}
-          {this.createTabHeader("sensingRecords", "計測実績")}
-          {this.createTabHeader("systemLogs", "ログ")}
-        </div>
-        {this.createTabContent("settingBasic",
-          <DevicesSummary
-            deviceId={this.props.deviceId}
-            device={this.props.device}
-           />
-        )}
-        {this.createTabContent("sensingRecords",
-          <DevicesPyranometerSensingRecords
-            deviceId={this.props.deviceId}
-           />
-        )}
-        {this.createTabContent("systemLogs",
-          <DevicesSystemLogs
-            deviceId={this.props.deviceId}
-           />
-        )}
-      </div>
+      <DeviceSettingTab
+        deviceId={this.props.deviceId}
+        device={this.props.device}
+        activeTabKey='sensingRecords'
+        tabs={[{
+          key: "settingBasic",
+          title: "基本設定",
+          component: DevicesSummary,
+        }, {
+          key: "sensingRecords",
+          title: "計測実績",
+          component: DevicesPyranometerSensingRecords,
+        }, {
+          key: "systemLogs",
+          title: "ログ",
+          component: DevicesSystemLogs,
+        }]}
+        />
     );
   }
 }

--- a/src/components/DevicesPyranometerTab.js
+++ b/src/components/DevicesPyranometerTab.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Logger from '../js/Logger'
-import DevicesSummary from './DevicesSummary'
+import DevicesSummary from '../containers/DevicesSummary'
 import DevicesPyranometerSensingRecords from '../containers/DevicesPyranometerSensingRecords'
 import DevicesSystemLogs from '../containers/DevicesSystemLogs'
 

--- a/src/components/DevicesWateringTab.js
+++ b/src/components/DevicesWateringTab.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Logger from '../js/Logger'
-import DevicesSummary from './DevicesSummary'
+import DevicesSummary from '../containers/DevicesSummary'
 import DevicesWateringSchedules from '../containers/DevicesWateringSchedules'
 import DevicesWateringOperationalRecords from '../containers/DevicesWateringOperationalRecords'
 import DevicesSystemLogs from '../containers/DevicesSystemLogs'

--- a/src/components/DevicesWateringTab.js
+++ b/src/components/DevicesWateringTab.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Logger from '../js/Logger'
+import DeviceSettingTab from './DeviceSettingTab'
 import DevicesSummary from '../containers/DevicesSummary'
 import DevicesWateringSchedules from '../containers/DevicesWateringSchedules'
 import DevicesWateringOperationalRecords from '../containers/DevicesWateringOperationalRecords'
@@ -8,78 +9,33 @@ import DevicesSystemLogs from '../containers/DevicesSystemLogs'
 export default class DevicesWateringTab extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      deviceId: '',
-      activeTab: 'operationalRecords',
-    };
-
     this.logger = new Logger({prefix: 'DevicesWateringTab'});
-    this.createTabHeader = this.createTabHeader.bind(this);
-    this.createTabContent = this.createTabContent.bind(this);
-    this.onTabClick = this.onTabClick.bind(this);
-  }
-
-  onTabClick(key) {
-    // タブ変更
-    this.setState({activeTab: key});
-  }
-
-  createTabHeader(key, content) {
-    // タブヘッダの作成
-    return(
-      <a className={"item " + (this.state.activeTab === key ? "active" : "")}
-        data-tab={key}
-        onClick={() => {this.onTabClick(key)}}
-      >
-        {content}
-      </a>
-      );
-  }
-
-  createTabContent(key, content) {
-    // タブコンテンツの作成
-    return (
-      <div className={"ui bottom attached tab segment " + (this.state.activeTab === key ? "active" : "")}
-        data-tab={key}
-      >
-        {content}
-      </div>
-    );
   }
 
   render() {
     return (
-      <div>
-        <div className="ui top attached tabular menu">
-          {this.createTabHeader("settingBasic", "基本設定")}
-          {this.createTabHeader("settingSchedules", "スケジュール")}
-          {this.createTabHeader("operationalRecords", "灌水実績")}
-          {this.createTabHeader("systemLogs", "ログ")}
-        </div>
-        {this.createTabContent("settingBasic",
-          <DevicesSummary
-            deviceId={this.props.deviceId}
-            device={this.props.device}
-           />
-        )}
-        {this.createTabContent("settingSchedules",
-          <DevicesWateringSchedules
-            deviceId={this.props.deviceId}
-            ref='table'
-           />
-        )}
-        {this.createTabContent("operationalRecords",
-          <DevicesWateringOperationalRecords
-            deviceId={this.props.deviceId}
-           />
-        )}
-        {this.createTabContent("systemLogs",
-          <DevicesSystemLogs
-            deviceId={this.props.deviceId}
-           />
-        )}
-      </div>
+      <DeviceSettingTab
+        deviceId={this.props.deviceId}
+        device={this.props.device}
+        activeTabKey='operationalRecords'
+        tabs={[{
+          key: "settingBasic",
+          title: "基本設定",
+          component: DevicesSummary,
+        }, {
+          key: "settingSchedules",
+          title: "スケジュール",
+          component: DevicesWateringSchedules,
+        }, {
+          key: "operationalRecords",
+          title: "灌水実績",
+          component: DevicesWateringOperationalRecords,
+        }, {
+          key: "systemLogs",
+          title: "ログ",
+          component: DevicesSystemLogs,
+        }]}
+        />
     );
   }
 }

--- a/src/constants/device.js
+++ b/src/constants/device.js
@@ -1,0 +1,10 @@
+const app = "@KF"
+const module = "DEVICE"
+const prefix = `${app}/${module}/`
+export const Device = {
+  LOAD_REQUEST: prefix + 'LOAD_REQUEST',
+  LOAD_SUCCESS: prefix + 'LOAD_SUCCESS',
+  LOAD_FAILURE: prefix + 'LOAD_FAILURE',
+  APP: prefix + 'APP',
+  SELECT: prefix + 'SELECT',
+}

--- a/src/constants/devicesPyranometer.js
+++ b/src/constants/devicesPyranometer.js
@@ -2,9 +2,6 @@ const app = "@KF"
 const module = "DEVICES_PYRANOMETER"
 const prefix = `${app}/${module}/`
 export const DevicesPyranometer = {
-  LOAD_REQUEST: prefix + 'LOAD_REQUEST',
-  LOAD_SUCCESS: prefix + 'LOAD_SUCCESS',
-  LOAD_FAILURE: prefix + 'LOAD_FAILURE',
   SELECT: prefix + 'SELECT',
   LOAD_SENSING_RECORDS_REQUEST: prefix + 'LOAD_SENSING_RECORDS_REQUEST',
   LOAD_SENSING_RECORDS_SUCCESS: prefix + 'LOAD_SENSING_RECORDS_SUCCESS',

--- a/src/constants/devicesWatering.js
+++ b/src/constants/devicesWatering.js
@@ -2,9 +2,6 @@ const app = "@KF"
 const module = "DEVICES_WATERING"
 const prefix = `${app}/${module}/`
 export const DevicesWatering = {
-  LOAD_REQUEST: prefix + 'LOAD_REQUEST',
-  LOAD_SUCCESS: prefix + 'LOAD_SUCCESS',
-  LOAD_FAILURE: prefix + 'LOAD_FAILURE',
   SELECT: prefix + 'SELECT',
   LOAD_SCHEDULES_REQUEST: prefix + 'LOAD_SCHEDULES_REQUEST',
   LOAD_SCHEDULES_SUCCESS: prefix + 'LOAD_SCHEDULES_SUCCESS',

--- a/src/containers/AppRoute.js
+++ b/src/containers/AppRoute.js
@@ -19,12 +19,13 @@ import DevicesPyranometers from './DevicesPyranometers';
 class AppRoute extends Component {
   constructor(props) {
     super(props);
+    this.state = {app: ''};
     this.logger = new Logger({prefix: 'AppRoute'});
   }
 
   render() {
     const PrivateRoute = ({ component: Component, ...rest }) => {
-      // this.logger.log('PrivateRoute', Component, rest);
+      // this.logger.log('PrivateRoute', rest, this.props, this.state);
       return (
         <Route {...rest} render={props => (
           this.props.isAuthenticated ? (
@@ -40,7 +41,7 @@ class AppRoute extends Component {
     }
 
     const AppLayoutRoute = ({match}, ...rest) => {
-      // this.logger.log('AppLayoutRoute', match, rest);
+      // this.logger.log('AppLayoutRoute', match, rest, this.props, this.state);
       return (
         <AppLayout match={match} rest={rest}>
           <Switch>

--- a/src/containers/AppRoute.js
+++ b/src/containers/AppRoute.js
@@ -19,7 +19,6 @@ import DevicesPyranometers from './DevicesPyranometers';
 class AppRoute extends Component {
   constructor(props) {
     super(props);
-    this.state = {app: ''};
     this.logger = new Logger({prefix: 'AppRoute'});
   }
 

--- a/src/containers/AppStore.js
+++ b/src/containers/AppStore.js
@@ -11,7 +11,6 @@ class AppStore extends Component {
     super(props);
     this.logger = new Logger({prefix: 'AppStore'});
     this.load = this.load.bind(this);
-    this.selectDevice = this.selectDevice.bind(this);
   }
 
   componentWillMount() {
@@ -43,20 +42,6 @@ class AppStore extends Component {
       });
   }
 
-  selectDevice(deviceId, force) {
-    this.props.actions.selectDevice(
-      deviceId,
-      this.props.devices,
-      force ? '' : this.props.selectedDeviceId
-    ).then(
-      result => {
-        // this.logger.log('selectDevice success:', result);
-      },
-      error => {
-        this.logger.error('selectDevice error:', error);
-      });
-  }
-
   render() {
     return (
       <div className='_appStore'/>
@@ -67,8 +52,6 @@ class AppStore extends Component {
 function mapStateToProps(state) {
   return  {
     typeSelectedDevice: state.device.get('typeSelectedDevice').toJS(),
-    selectedDeviceId: state.device.get('selectedDeviceId'),
-    devices: state.device.get('devices').toJS(),
     selectedApp: state.device.get('selectedApp'),
   };
 }

--- a/src/containers/AppStore.js
+++ b/src/containers/AppStore.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+
+import Logger from '../js/Logger';
+
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as Actions from '../actions/device';
+
+class AppStore extends Component {
+  constructor(props) {
+    super(props);
+    this.logger = new Logger({prefix: 'AppStore'});
+    this.load = this.load.bind(this);
+    this.selectApp = this.selectApp.bind(this);
+    this.selectDevice = this.selectDevice.bind(this);
+  }
+
+  componentWillMount() {
+    // マウント時にデバイス情報をロードする
+    this.logger.info('conponentWillMount', "props", this.props);
+    this.load();
+  }
+
+  load() {
+    // デバイス情報をロード
+    this.props.actions.loadDevices();
+  }
+
+  selectApp(name) {
+    console.log('aaa', name);
+    // this.logger.info('ref select App:', name);
+    // this.props.actions.selectApp(name);
+  }
+
+  selectDevice(deviceId) {
+    this.props.actions.selectDevice(deviceId, this.props.devices, this.props.deviceId);
+    // this.props.actions.selectDevice(deviceId);
+  }
+
+  render() {
+    return (
+      <div className='_appStore'/>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return  {
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return { actions: bindActionCreators(Actions, dispatch) };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null,
+  { withRef: true }
+)(AppStore);

--- a/src/containers/AppStore.js
+++ b/src/containers/AppStore.js
@@ -11,30 +11,50 @@ class AppStore extends Component {
     super(props);
     this.logger = new Logger({prefix: 'AppStore'});
     this.load = this.load.bind(this);
-    this.selectApp = this.selectApp.bind(this);
     this.selectDevice = this.selectDevice.bind(this);
   }
 
   componentWillMount() {
     // マウント時にデバイス情報をロードする
-    this.logger.info('conponentWillMount', "props", this.props);
+    // this.logger.info('conponentWillMount', "props", this.props);
     this.load();
   }
 
   load() {
     // デバイス情報をロード
-    this.props.actions.loadDevices();
+    this.props.actions.loadDevices().then(
+      result => {
+        // 初期選択デバイスの情報読み込み
+        // this.logger.log('load success:', this.props);
+        return this.props.actions.initialLoadDeviceInformations(
+          this.props.selectedApp,
+          this.props.typeSelectedDevice
+        )
+      },
+      error => {
+        this.logger.error('load error:', error);
+    }).then(
+      result => {
+        // 初期選択デバイスの情報読み込み完了
+        // this.logger.log('load info complete:', this.props);
+      },
+      error => {
+        this.logger.error('load info error:', error);
+      });
   }
 
-  selectApp(name) {
-    console.log('aaa', name);
-    // this.logger.info('ref select App:', name);
-    // this.props.actions.selectApp(name);
-  }
-
-  selectDevice(deviceId) {
-    this.props.actions.selectDevice(deviceId, this.props.devices, this.props.deviceId);
-    // this.props.actions.selectDevice(deviceId);
+  selectDevice(deviceId, force) {
+    this.props.actions.selectDevice(
+      deviceId,
+      this.props.devices,
+      force ? '' : this.props.selectedDeviceId
+    ).then(
+      result => {
+        // this.logger.log('selectDevice success:', result);
+      },
+      error => {
+        this.logger.error('selectDevice error:', error);
+      });
   }
 
   render() {
@@ -46,6 +66,10 @@ class AppStore extends Component {
 
 function mapStateToProps(state) {
   return  {
+    typeSelectedDevice: state.device.get('typeSelectedDevice').toJS(),
+    selectedDeviceId: state.device.get('selectedDeviceId'),
+    devices: state.device.get('devices').toJS(),
+    selectedApp: state.device.get('selectedApp'),
   };
 }
 
@@ -56,6 +80,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-  null,
-  { withRef: true }
 )(AppStore);

--- a/src/containers/DeviceSetting.js
+++ b/src/containers/DeviceSetting.js
@@ -14,9 +14,11 @@ class DevicesSetting extends Component {
   }
 
   onChangeDevice(id) {
-    // デバイスを選択状態にする
     // TODO 保存がされてない場合は変更時に警告する
-    this.props.actions.selectDevice(id, this.props.devices, this.props.deviceId);
+    if (id !== this.props.deviceId) {
+      // デバイスをが変更された場合
+      this.props.actions.selectDevice(id, this.props.devices);
+    }
   }
 
   render() {

--- a/src/containers/DeviceSetting.js
+++ b/src/containers/DeviceSetting.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import { Grid, Menu } from 'semantic-ui-react';
+import Logger from '../js/Logger';
+
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as Actions from '../actions/device';
+
+class DevicesSetting extends Component {
+  constructor(props) {
+    super(props);
+    this.logger = new Logger({prefix: 'DevicesPyranometers'});
+    this.onChangeDevice = this.onChangeDevice.bind(this);
+  }
+
+  onChangeDevice(id) {
+    // デバイスを選択状態にする
+    // TODO 保存がされてない場合は変更時に警告する
+    this.props.actions.selectDevice(id, this.props.devices, this.props.deviceId);
+  }
+
+  render() {
+    return (
+      <div>
+        <Grid columns={2}>
+          <Grid.Column width={3}>
+            <Menu
+              fluid
+              vertical
+              secondary
+              pointing
+              items={this.props.typeNames[this.props.type]}
+              onItemClick={(event, data) => {this.onChangeDevice(data.id);}}
+              />
+
+          </Grid.Column>
+          <Grid.Column stretched width={13}>
+            {<this.props.component
+              deviceId = {this.props.deviceId}
+              device = {this.props.device}
+            />}
+          </Grid.Column>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  // console.log('state qqq: ', state.device.toJS());
+  return  {
+    typeNames: state.device.get('typeNames').toJS(),
+    deviceId: state.device.get('selectedDeviceId'),
+    devices: state.device.get('devices').toJS(),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return { actions: bindActionCreators(Actions, dispatch) };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DevicesSetting);

--- a/src/containers/DevicesPyranometerSensingRecords.js
+++ b/src/containers/DevicesPyranometerSensingRecords.js
@@ -55,7 +55,6 @@ class DevicesPyranometerSensingRecords extends React.Component {
 
 function mapStateToProps(state) {
   return  {
-    selectedDevicesPyranometerId: state.devicesPyranometer.get('selectedId'),
     devicesPyranometerSensingRecords: state.devicesPyranometer.get('sensingRecords').toJS(),
     progress: state.devicesPyranometer.get('progress'),
   };

--- a/src/containers/DevicesPyranometers.js
+++ b/src/containers/DevicesPyranometers.js
@@ -5,31 +5,19 @@ import DevicesPyranometerTab from '../components/DevicesPyranometerTab';
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as Actions from '../actions/devicesPyranometer';
+import * as Actions from '../actions/device';
 
 class DevicesPyranometers extends Component {
   constructor(props) {
     super(props);
     this.logger = new Logger({prefix: 'DevicesPyranometers'});
     this.onChangeDevice = this.onChangeDevice.bind(this);
-    this.load = this.load.bind(this);
-  }
-
-  componentWillMount() {
-    // マウント時にデバイス情報をロードする
-    this.logger.info('conponentWillMount', "props", this.props);
-    this.load();
-  }
-
-  load() {
-    // デバイス情報をロード
-    this.props.actions.loadDevicesPyranometers();
   }
 
   onChangeDevice(id) {
     // デバイスを選択状態にする
     // TODO 保存がされてない場合は変更時に警告する
-    this.props.actions.selectDevicesPyranometer(id, this.props.selectedDevicesPyranometerId);
+    this.props.actions.selectDevice(id, this.props.devices, this.props.deviceId);
   }
 
   render() {
@@ -49,8 +37,8 @@ class DevicesPyranometers extends Component {
           </Grid.Column>
           <Grid.Column stretched width={13}>
             <DevicesPyranometerTab
-              deviceId = {this.props.selectedDevicesPyranometerId}
-              device = {this.props.selectedDevicesPyranometer}
+              deviceId = {this.props.deviceId}
+              device = {this.props.device}
               />
           </Grid.Column>
         </Grid>
@@ -60,10 +48,12 @@ class DevicesPyranometers extends Component {
 }
 
 function mapStateToProps(state) {
+  // console.log('state qqq: ', state.device.toJS());
   return  {
-    names: state.devicesPyranometer.get('names').toJS(),
-    selectedDevicesPyranometerId: state.devicesPyranometer.get('selectedId'),
-    selectedDevicesPyranometer: state.devicesPyranometer.get('selected').toJS(),
+    names: state.device.getIn(['typeNames', 'pyranometer']) ? state.device.getIn(['typeNames', 'pyranometer']).toJS() : [],
+    deviceId: state.device.get('selectedId'),
+    device: state.device.get('selected').toJS(),
+    devices: state.device.get('devices').toJS(),
   };
 }
 

--- a/src/containers/DevicesPyranometers.js
+++ b/src/containers/DevicesPyranometers.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import { Grid, Menu } from 'semantic-ui-react';
 import Logger from '../js/Logger';
+
+import DeviceSetting from './DeviceSetting';
 import DevicesPyranometerTab from '../components/DevicesPyranometerTab';
 
 import { bindActionCreators } from 'redux';
@@ -10,51 +11,23 @@ import * as Actions from '../actions/device';
 class DevicesPyranometers extends Component {
   constructor(props) {
     super(props);
+    this.state = {app: 'pyranometer'};
     this.logger = new Logger({prefix: 'DevicesPyranometers'});
-    this.onChangeDevice = this.onChangeDevice.bind(this);
   }
 
-  onChangeDevice(id) {
-    // デバイスを選択状態にする
-    // TODO 保存がされてない場合は変更時に警告する
-    this.props.actions.selectDevice(id, this.props.devices, this.props.deviceId);
+  componentWillMount() {
+    // this.logger.info('conponentWillMount', "props", this.props);
+    this.props.actions.selectApp(this.state.app);
   }
 
   render() {
     return (
-      <div>
-        <Grid columns={2}>
-          <Grid.Column width={3}>
-            <Menu
-              fluid
-              vertical
-              secondary
-              pointing
-              items={this.props.names}
-              onItemClick={(event, data) => {this.onChangeDevice(data.id);}}
-              />
-
-          </Grid.Column>
-          <Grid.Column stretched width={13}>
-            <DevicesPyranometerTab
-              deviceId = {this.props.deviceId}
-              device = {this.props.device}
-              />
-          </Grid.Column>
-        </Grid>
-      </div>
+      <DeviceSetting
+        type={this.state.app}
+        component={DevicesPyranometerTab}
+        />
     );
   }
-}
-
-function mapStateToProps(state) {
-  // console.log('state qqq: ', state.device.toJS());
-  return  {
-    names: state.device.getIn(['typeNames', 'pyranometer']) ? state.device.getIn(['typeNames', 'pyranometer']).toJS() : [],
-    deviceId: state.device.get('selectedId'),
-    device: state.device.get('selected').toJS(),
-    devices: state.device.get('devices').toJS(),
-  };
 }
 
 function mapDispatchToProps(dispatch) {
@@ -62,6 +35,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(
-  mapStateToProps,
-  mapDispatchToProps
+  null,
+  mapDispatchToProps,
 )(DevicesPyranometers);

--- a/src/containers/DevicesSummary.js
+++ b/src/containers/DevicesSummary.js
@@ -53,7 +53,7 @@ class DevicesSummary extends Component {
 
 function mapStateToProps(state) {
   return  {
-    device: state.device.get('selected').toJS(),
+    device: state.device.get('selectedDevice').toJS(),
   };
 }
 

--- a/src/containers/DevicesSummary.js
+++ b/src/containers/DevicesSummary.js
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import { Feed } from 'semantic-ui-react';
 import Logger from '../js/Logger'
 
-export default class DevicesSummary extends Component {
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as Actions from '../actions/device';
+
+class DevicesSummary extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-    };
 
     this.logger = new Logger({prefix: 'DevicesSummary'});
     this.createFeed = this.createFeed.bind(this);
@@ -45,8 +46,22 @@ export default class DevicesSummary extends Component {
           {this.createFeed('inserted_at', this.props.device.inserted_at)}
           {this.createFeed('updated_at', this.props.device.updated_at)}
         </div>
-
       </div>
     );
   }
 }
+
+function mapStateToProps(state) {
+  return  {
+    device: state.device.get('selected').toJS(),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return { actions: bindActionCreators(Actions, dispatch) };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DevicesSummary);

--- a/src/containers/DevicesWateringOperationalRecords.js
+++ b/src/containers/DevicesWateringOperationalRecords.js
@@ -63,7 +63,6 @@ class DevicesWateringOperationalRecords extends React.Component {
 
 function mapStateToProps(state) {
   return  {
-    selectedDevicesWateringId: state.devicesWatering.get('selectedId'),
     devicesWateringOperationalRecords: state.devicesWatering.get('operationalRecords').toJS(),
     progress: state.devicesWatering.get('progress'),
   };

--- a/src/containers/DevicesWateringSchedules.js
+++ b/src/containers/DevicesWateringSchedules.js
@@ -45,7 +45,7 @@ class DevicesWateringSchedules extends React.Component {
 
   load() {
     // ロードボタンクリック時の処理
-    this.props.actions.loadDevicesWateringSchedules(this.props.selectedDevicesWateringId);
+    this.props.actions.loadDevicesWateringSchedules(this.props.device.id);
   }
 
   save() {
@@ -57,7 +57,7 @@ class DevicesWateringSchedules extends React.Component {
 
   add() {
     // スケジュール追加ボタンクリック時の処理
-    this.props.actions.addDevicesWateringSchedule();
+    this.props.actions.addDevicesWateringSchedule(this.props.device.id);
   }
 
   remove(event, data, row, args) {
@@ -143,7 +143,7 @@ class DevicesWateringSchedules extends React.Component {
 
 function mapStateToProps(state) {
   return  {
-    selectedDevicesWateringId: state.devicesWatering.get('selectedId'),
+    device: state.devicesWatering.get('device').toJS(),
     devicesWateringSchedules: state.devicesWatering.get('schedules').toJS(),
     devicesWateringSchedulesChanged: state.devicesWatering.get('changed').toJS(),
     progress: state.devicesWatering.get('progress'),

--- a/src/containers/DevicesWaterings.js
+++ b/src/containers/DevicesWaterings.js
@@ -1,60 +1,34 @@
 import React, { Component } from 'react';
-import { Grid, Menu } from 'semantic-ui-react';
 import Logger from '../js/Logger';
+
+import DeviceSetting from './DeviceSetting';
 import DevicesWateringTab from '../components/DevicesWateringTab';
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as Actions from '../actions/device';
 
+
 class DevicesWaterings extends Component {
   constructor(props) {
     super(props);
+    this.state = {app: 'watering'};
     this.logger = new Logger({prefix: 'DevicesWaterings'});
-    this.onChangeDevice = this.onChangeDevice.bind(this);
   }
 
-  onChangeDevice(id) {
-    // デバイスを選択状態にする
-    // TODO 保存がされてない場合は変更時に警告する
-    this.props.actions.selectDevice(id, this.props.devices, this.props.deviceId);
+  componentWillMount() {
+    // this.logger.info('conponentWillMount', "props", this.props);
+    this.props.actions.selectApp(this.state.app);
   }
 
   render() {
     return (
-      <div>
-        <Grid columns={2}>
-          <Grid.Column width={3}>
-            <Menu
-              fluid
-              vertical
-              secondary
-              pointing
-              items={this.props.names}
-              onItemClick={(event, data) => {this.onChangeDevice(data.id);}}
-              />
-
-          </Grid.Column>
-          <Grid.Column stretched width={13}>
-            <DevicesWateringTab
-              deviceId = {this.props.deviceId}
-              device = {this.props.device}
-              />
-          </Grid.Column>
-        </Grid>
-      </div>
+      <DeviceSetting
+        type={this.state.app}
+        component={DevicesWateringTab}
+        />
     );
   }
-}
-
-function mapStateToProps(state) {
-  // console.log('state ppp: ', state.device.toJS());
-  return  {
-    names: state.device.getIn(['typeNames', 'watering']).toJS(),
-    deviceId: state.device.get('selectedId'),
-    device: state.device.get('selected').toJS(),
-    devices: state.device.get('devices').toJS(),
-  };
 }
 
 function mapDispatchToProps(dispatch) {
@@ -62,6 +36,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(
-  mapStateToProps,
-  mapDispatchToProps
+  null,
+  mapDispatchToProps,
 )(DevicesWaterings);

--- a/src/containers/DevicesWaterings.js
+++ b/src/containers/DevicesWaterings.js
@@ -5,31 +5,19 @@ import DevicesWateringTab from '../components/DevicesWateringTab';
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as Actions from '../actions/devicesWatering';
+import * as Actions from '../actions/device';
 
 class DevicesWaterings extends Component {
   constructor(props) {
     super(props);
     this.logger = new Logger({prefix: 'DevicesWaterings'});
     this.onChangeDevice = this.onChangeDevice.bind(this);
-    this.load = this.load.bind(this);
-  }
-
-  componentWillMount() {
-    // マウント時にデバイス情報をロードする
-    this.logger.info('conponentWillMount', "props", this.props);
-    this.load();
-  }
-
-  load() {
-    // デバイス情報をロード
-    this.props.actions.loadDevicesWaterings();
   }
 
   onChangeDevice(id) {
     // デバイスを選択状態にする
     // TODO 保存がされてない場合は変更時に警告する
-    this.props.actions.selectDevicesWatering(id, this.props.selectedDevicesWateringId);
+    this.props.actions.selectDevice(id, this.props.devices, this.props.deviceId);
   }
 
   render() {
@@ -49,8 +37,8 @@ class DevicesWaterings extends Component {
           </Grid.Column>
           <Grid.Column stretched width={13}>
             <DevicesWateringTab
-              deviceId = {this.props.selectedDevicesWateringId}
-              device = {this.props.selectedDevicesWatering}
+              deviceId = {this.props.deviceId}
+              device = {this.props.device}
               />
           </Grid.Column>
         </Grid>
@@ -60,10 +48,12 @@ class DevicesWaterings extends Component {
 }
 
 function mapStateToProps(state) {
+  // console.log('state ppp: ', state.device.toJS());
   return  {
-    names: state.devicesWatering.get('names').toJS(),
-    selectedDevicesWateringId: state.devicesWatering.get('selectedId'),
-    selectedDevicesWatering: state.devicesWatering.get('selected').toJS(),
+    names: state.device.getIn(['typeNames', 'watering']).toJS(),
+    deviceId: state.device.get('selectedId'),
+    device: state.device.get('selected').toJS(),
+    devices: state.device.get('devices').toJS(),
   };
 }
 

--- a/src/layouts/AppLayout.js
+++ b/src/layouts/AppLayout.js
@@ -21,11 +21,8 @@ class AppLayout extends Component {
   }
 
   handleMenubarItemClick(e, item) {
-    this.logger.info('handleMenubarItemClick', e, item);
-    this.logger.info('refs', this.refs);
-    this.logger.info('refs', this.refs.getWrappedInstance());
-    // this.refs.ppp.aaa(item);
-    // this.setState({ activeMenubarItem: item });
+    // this.logger.info('handleMenubarItemClick', e, item);
+    this.setState({ activeMenubarItem: item });
   }
 
   render() {

--- a/src/layouts/AppLayout.js
+++ b/src/layouts/AppLayout.js
@@ -3,6 +3,7 @@ import '../components/App.css';
 import { Segment } from 'semantic-ui-react';
 import Logger from '../js/Logger';
 import Menubar from '../containers/MenuBar';
+import AppStore from '../containers/AppStore';
 
 class AppLayout extends Component {
   constructor(props) {
@@ -20,13 +21,17 @@ class AppLayout extends Component {
   }
 
   handleMenubarItemClick(e, item) {
-    // this.logger.info('handleMenubarItemClick', e, item);
-    this.setState({ activeMenubarItem: item });
+    this.logger.info('handleMenubarItemClick', e, item);
+    this.logger.info('refs', this.refs);
+    this.logger.info('refs', this.refs.getWrappedInstance());
+    // this.refs.ppp.aaa(item);
+    // this.setState({ activeMenubarItem: item });
   }
 
   render() {
     return (
       <Segment>
+        <AppStore ref="app_store" />
         <Menubar
           visible={this.state.visible}
           handleMenubarItemClick={this.handleMenubarItemClick}

--- a/src/reducers/device.js
+++ b/src/reducers/device.js
@@ -91,17 +91,19 @@ const device = (state = initialDevice, action) => {
 
       // 指定された要素を選択状態にする
       // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
+
+      let device = GtbUtils.find(state.get('devices').toJS(), 'id', action.id);
       return state.withMutations(map => { map
         .set('selectedDeviceId', action.id)
-        .set('selectedDevice', fromJS(action.device))
-        .setIn(['typeSelectedDeviceId', action.device.device_type], action.id)
-        .setIn(['typeSelectedDevice', action.device.device_type], fromJS(action.device))
+        .set('selectedDevice', fromJS(device))
+        .setIn(['typeSelectedDeviceId', device.device_type], action.id)
+        .setIn(['typeSelectedDevice', device.device_type], fromJS(device))
         .update('names', list => list.map(
             // 選択されたidであればtrue、それ以外はfalseに更新する
             object => object.set('active', object.get('id') === action.id)
           )
         )
-        .updateIn(['typeNames', action.device.device_type], list => list.map(
+        .updateIn(['typeNames', device.device_type], list => list.map(
             // 選択されたidであればtrue、それ以外はfalseに更新する
             object => object.set('active', object.get('id') === action.id)
           )

--- a/src/reducers/device.js
+++ b/src/reducers/device.js
@@ -8,13 +8,14 @@ import GtbUtils from '../js/GtbUtils'
 const initialDevice = Map({
   'names': List([]),
   'devices': List([]),
-  'selectedId': '',
-  'selected': Map({}),
+  'selectedApp': '',
+  'selectedDeviceId': '',
+  'selectedDevice': Map({}),
 
   'typeNames': fromJS({watering: [], pyranometer: [],}),
   'typeDevices': fromJS({watering: [], pyranometer: [],}),
-  'typeSelectedId': fromJS({watering: '', pyranometer: '',}),
-  'typeSelected': fromJS({watering: {}, pyranometer: {},}),
+  'typeSelectedDeviceId': fromJS({watering: '', pyranometer: '',}),
+  'typeSelectedDevice': fromJS({watering: {}, pyranometer: {},}),
 
   'progress': false,
 });
@@ -53,21 +54,21 @@ const device = (state = initialDevice, action) => {
       let typeNames = toTypeNames(devices);
 
       // それぞれの先頭要素を選択状態にする
-      let selectedId = selectFirst(names);
-      let typeSelectedId = selectsFirst(typeNames);
+      let selectedDeviceId = selectFirst(names);
+      let typeSelectedDeviceId = selectsFirst(typeNames);
 
-      let selected = get(selectedId, devices);
-      let typeSelected = gets(typeSelectedId, devices);
+      let selectedDevice = get(selectedDeviceId, devices);
+      let typeSelectedDevice = gets(typeSelectedDeviceId, devices);
 
       return state.withMutations(map => { map
         .set('names', fromJS(names))
         .set('devices', fromJS(devices))
-        .set('selectedId', selectedId)
-        .set('selected', fromJS(selected))
+        .set('selectedDeviceId', selectedDeviceId)
+        .set('selectedDevice', fromJS(selectedDevice))
         .set('typeNames', fromJS({watering: [], pyranometer: [],}).mergeDeep(fromJS(typeNames)))
         .set('typeDevices', fromJS({watering: [], pyranometer: [],}).mergeDeep(fromJS(typeDevices)))
-        .set('typeSelectedId', fromJS({watering: '', pyranometer: '',}).mergeDeep(fromJS(typeSelectedId)))
-        .set('typeSelected', fromJS({watering: {}, pyranometer: {},}).mergeDeep(fromJS(typeSelected)))
+        .set('typeSelectedDeviceId', fromJS({watering: '', pyranometer: '',}).mergeDeep(fromJS(typeSelectedDeviceId)))
+        .set('typeSelectedDevice', fromJS({watering: {}, pyranometer: {},}).mergeDeep(fromJS(typeSelectedDevice)))
         .set('progress', false)
         ;
       });
@@ -80,8 +81,9 @@ const device = (state = initialDevice, action) => {
       // APPの選択
       // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
       return state.withMutations(map => { map
-        .set('selectedId', state.getIn(['typeSelectedId', action.app]))
-        .set('selected', state.getIn(['typeSelected', action.app]))
+        .set('selectedApp', action.app)
+        .set('selectedDeviceId', state.getIn(['typeSelectedDeviceId', action.app]))
+        .set('selectedDevice', state.getIn(['typeSelectedDevice', action.app]))
       });
 
     case Device.SELECT:
@@ -89,12 +91,11 @@ const device = (state = initialDevice, action) => {
 
       // 指定された要素を選択状態にする
       // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
-
       return state.withMutations(map => { map
-        .set('selectedId', action.id)
-        .set('selected', fromJS(action.device))
-        .setIn(['typeSelectedId', action.device.device_type], action.id)
-        .setIn(['typeSelected', action.device.device_type], action.device)
+        .set('selectedDeviceId', action.id)
+        .set('selectedDevice', fromJS(action.device))
+        .setIn(['typeSelectedDeviceId', action.device.device_type], action.id)
+        .setIn(['typeSelectedDevice', action.device.device_type], fromJS(action.device))
         .update('names', list => list.map(
             // 選択されたidであればtrue、それ以外はfalseに更新する
             object => object.set('active', object.get('id') === action.id)
@@ -177,10 +178,10 @@ const get = (id, devices) => {
   return GtbUtils.find(devices, 'id', id);
 }
 
-const gets = (typeSelectedId, names) => {
+const gets = (typeSelectedDeviceId, names) => {
   let hash = {};
-  Object.keys(typeSelectedId).forEach((key) => {
-    let id = typeSelectedId[key];
+  Object.keys(typeSelectedDeviceId).forEach((key) => {
+    let id = typeSelectedDeviceId[key];
     hash[key] = get(id, names);
   });
   return hash;

--- a/src/reducers/device.js
+++ b/src/reducers/device.js
@@ -1,0 +1,189 @@
+import { List, Map, fromJS } from 'immutable';
+import { Device } from '../constants/device';
+import GtbUtils from '../js/GtbUtils'
+
+// import Logger from '../js/Logger'
+// const _logger = new Logger({prefix: 'devicesWatering'});
+
+const initialDevice = Map({
+  'names': List([]),
+  'devices': List([]),
+  'selectedId': '',
+  'selected': Map({}),
+
+  'typeNames': fromJS({watering: [], pyranometer: [],}),
+  'typeDevices': fromJS({watering: [], pyranometer: [],}),
+  'typeSelectedId': fromJS({watering: '', pyranometer: '',}),
+  'typeSelected': fromJS({watering: {}, pyranometer: {},}),
+
+  'progress': false,
+});
+
+const device = (state = initialDevice, action) => {
+  // _logger.info('state :', state.toJS());
+  // _logger.info('action :', action);
+
+  switch (action.type) {
+    case Device.LOAD_REQUEST:
+      // デバイス情報の取得開始
+      return state.set('progress', true);
+
+    case Device.LOAD_SUCCESS:
+      // デバイス情報の取得完了
+      let devices = action.list.map((value) => {
+          let map = {
+            id: value["id"],
+            device_type: value["device_type"],
+            name: value["name"],
+            software_version: value["software_version"],
+            model_number: value["model_number"],
+            heartbeated_at: GtbUtils.dateString(new Date(value["heartbeated_at"])),
+            inserted_at: GtbUtils.dateString(new Date(value["inserted_at"])),
+            updated_at: GtbUtils.dateString(new Date(value["updated_at"])),
+          };
+          if ('order_amount' in value) {
+            map.order_amount = value["order_amount"]
+          }
+          return map;
+        });
+
+      let typeDevices = toTypeDevices(devices);
+
+      let names = toNames(devices);
+      let typeNames = toTypeNames(devices);
+
+      // それぞれの先頭要素を選択状態にする
+      let selectedId = selectFirst(names);
+      let typeSelectedId = selectsFirst(typeNames);
+
+      let selected = get(selectedId, devices);
+      let typeSelected = gets(typeSelectedId, devices);
+
+      return state.withMutations(map => { map
+        .set('names', fromJS(names))
+        .set('devices', fromJS(devices))
+        .set('selectedId', selectedId)
+        .set('selected', fromJS(selected))
+        .set('typeNames', fromJS({watering: [], pyranometer: [],}).mergeDeep(fromJS(typeNames)))
+        .set('typeDevices', fromJS({watering: [], pyranometer: [],}).mergeDeep(fromJS(typeDevices)))
+        .set('typeSelectedId', fromJS({watering: '', pyranometer: '',}).mergeDeep(fromJS(typeSelectedId)))
+        .set('typeSelected', fromJS({watering: {}, pyranometer: {},}).mergeDeep(fromJS(typeSelected)))
+        .set('progress', false)
+        ;
+      });
+
+    case Device.LOAD_FAILURE:
+      // デバイス情報の取得失敗
+      return state.set('progress', false);
+
+    case Device.APP:
+      // APPの選択
+      // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
+      return state.withMutations(map => { map
+        .set('selectedId', state.getIn(['typeSelectedId', action.app]))
+        .set('selected', state.getIn(['typeSelected', action.app]))
+      });
+
+    case Device.SELECT:
+      // デバイスの選択
+
+      // 指定された要素を選択状態にする
+      // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
+
+      return state.withMutations(map => { map
+        .set('selectedId', action.id)
+        .set('selected', fromJS(action.device))
+        .setIn(['typeSelectedId', action.device.device_type], action.id)
+        .setIn(['typeSelected', action.device.device_type], action.device)
+        .update('names', list => list.map(
+            // 選択されたidであればtrue、それ以外はfalseに更新する
+            object => object.set('active', object.get('id') === action.id)
+          )
+        )
+        .updateIn(['typeNames', action.device.device_type], list => list.map(
+            // 選択されたidであればtrue、それ以外はfalseに更新する
+            object => object.set('active', object.get('id') === action.id)
+          )
+        )
+      });
+
+    default:
+      return state;
+  }
+}
+
+const toTypeDevices = (devices) => {
+  let hash = {}
+  for (let device of devices) {
+    if (!(device.device_type in hash)) {
+      hash[device.device_type] = [];
+    }
+    hash[device.device_type].push(device);
+  }
+  return hash;
+}
+
+const toName = (device) => {
+  return {
+    key: device["id"],
+    id: device["id"],
+    name: device["name"],
+    active: false,
+  };
+}
+
+const toNames = (devices) => {
+  return devices.map((device) => {
+    return toName(device);
+  });
+}
+
+const toTypeNames = (devices) => {
+  let hash = {}
+  for (let device of devices) {
+    if (!(device.device_type in hash)) {
+      hash[device.device_type] = [];
+    }
+    hash[device.device_type].push(toName(device));
+  }
+  return hash;
+}
+
+const selectsFirst = (typeNames) => {
+  let hash = {};
+  Object.keys(typeNames).forEach((key) => {
+    hash[key] = selectFirst(typeNames[key]);
+  });
+  return hash;
+}
+
+const selectFirst = (names) => {
+  if (1 <= names.length) {
+    let id = names[0].id;
+    select(id, names);
+    return id;
+  } else {
+    return '';
+  }
+}
+
+const select = (id, names) => {
+  for(let name of names) {
+    name.active = name.id === id;
+  }
+}
+
+const get = (id, devices) => {
+  return GtbUtils.find(devices, 'id', id);
+}
+
+const gets = (typeSelectedId, names) => {
+  let hash = {};
+  Object.keys(typeSelectedId).forEach((key) => {
+    let id = typeSelectedId[key];
+    hash[key] = get(id, names);
+  });
+  return hash;
+}
+
+export default device;

--- a/src/reducers/devicesPyranometer.js
+++ b/src/reducers/devicesPyranometer.js
@@ -6,10 +6,7 @@ import GtbUtils from '../js/GtbUtils'
 // const _logger = new Logger({prefix: 'devicesPyranometer'});
 
 const initialDevicesPyranometer = Map({
-  'names': List([]),
-  'devices': List([]),
-  'selectedId': '',
-  'selected': Map({}),
+  'device': Map({}),
   'sensingRecords': List([]),
   'progress': false,
 });
@@ -19,62 +16,8 @@ const devicePyranometer = (state = initialDevicesPyranometer, action) => {
   // _logger.info('action :', action);
 
   switch (action.type) {
-    case DevicesPyranometer.LOAD_REQUEST:
-      // デバイス情報の取得開始
-      return state.set('progress', true);
-
-    case DevicesPyranometer.LOAD_SUCCESS:
-      // デバイス情報の取得完了
-      let names = action.list.map((value) => {
-          return {
-            key: value["id"],
-            id: value["id"],
-            name: value["name"],
-            active: false,
-          };
-        });
-
-      let devices = action.list.map((value) => {
-          return {
-            id: value["id"],
-            device_type: value["device_type"],
-            name: value["name"],
-            software_version: value["software_version"],
-            model_number: value["model_number"],
-            heartbeated_at: GtbUtils.dateString(new Date(value["heartbeated_at"])),
-            inserted_at: GtbUtils.dateString(new Date(value["inserted_at"])),
-            updated_at: GtbUtils.dateString(new Date(value["updated_at"])),
-          };
-        });
-
-      return state.withMutations(map => { map
-        .set('names', fromJS(names))
-        .set('devices', fromJS(devices))
-        .set('selectedId', '')
-        .set('selected', Map({}))
-        .set('progress', false)
-        ;
-      });
-
-    case DevicesPyranometer.LOAD_FAILURE:
-      // デバイス情報の取得失敗
-      return state.set('progress', false);
-
     case DevicesPyranometer.SELECT:
-      // デバイスの選択
-
-      // 指定された要素を選択状態にする
-      // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
-
-      return state.withMutations(map => { map
-        .set('selectedId', action.id)
-        .update('names', list => list.map(
-            // 選択されたidであればtrue、それ以外はfalseに更新する
-            object => object.set('active', object.get('id') === action.id)
-          )
-        )
-        .set('selected', map.get('devices').find(object => object.get('id') === action.id))
-      });
+      return state.set('device', fromJS(action.device));
 
     case DevicesPyranometer.LOAD_SENSING_RECORDS_REQUEST:
       // 実績の取得開始

--- a/src/reducers/devicesWatering.js
+++ b/src/reducers/devicesWatering.js
@@ -6,11 +6,8 @@ import GtbUtils from '../js/GtbUtils'
 // const _logger = new Logger({prefix: 'devicesWatering'});
 
 const initialDevicesWatering = Map({
-  'names': List([]),
-  'devices': List([]),
+  'device': Map({}),
   'schedules': List([]),
-  'selectedId': '',
-  'selected': Map({}),
   'changed': Map({}),
   'operationalRecords': List([]),
   'progress': false,
@@ -21,63 +18,8 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
   // _logger.info('action :', action);
 
   switch (action.type) {
-    case DevicesWatering.LOAD_REQUEST:
-      // デバイス情報の取得開始
-      return state.set('progress', true);
-
-    case DevicesWatering.LOAD_SUCCESS:
-      // デバイス情報の取得完了
-      let names = action.list.map((value) => {
-          return {
-            key: value["id"],
-            id: value["id"],
-            name: value["name"],
-            active: false,
-          };
-        });
-      let devices = action.list.map((value) => {
-          return {
-            id: value["id"],
-            device_type: value["device_type"],
-            name: value["name"],
-            software_version: value["software_version"],
-            model_number: value["model_number"],
-            heartbeated_at: GtbUtils.dateString(new Date(value["heartbeated_at"])),
-            inserted_at: GtbUtils.dateString(new Date(value["inserted_at"])),
-            updated_at: GtbUtils.dateString(new Date(value["updated_at"])),
-          };
-        });
-
-      return state.withMutations(map => { map
-        .set('names', fromJS(names))
-        .set('devices', fromJS(devices))
-        .set('schedules', List([]))
-        .set('changed', Map({}))
-        .set('selectedId', '')
-        .set('selected', Map({}))
-        .set('progress', false)
-        ;
-      });
-
-    case DevicesWatering.LOAD_FAILURE:
-      // デバイス情報の取得失敗
-      return state.set('progress', false);
-
     case DevicesWatering.SELECT:
-      // デバイスの選択
-
-      // 指定された要素を選択状態にする
-      // TODO viewのために仕方なく必要な処理であるため、ここでやるべきではないかも
-
-      return state.withMutations(map => { map
-        .set('selectedId', action.id)
-        .update('names', list => list.map(
-            // 選択されたidであればtrue、それ以外はfalseに更新する
-            object => object.set('active', object.get('id') === action.id)
-          )
-        )
-        .set('selected', map.get('devices').find(object => object.get('id') === action.id))
-      });
+      return state.set('device', fromJS(action.device));
 
     case DevicesWatering.LOAD_SCHEDULES_REQUEST:
       // スケジュール情報の取得開始
@@ -171,7 +113,7 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
       // 行を作成して追加
       var row = Map({
         id: tmpId,
-        device_id: state.get('selectedId'),
+        device_id: action.params.deviceId,
         _state: 'create',
       })
 

--- a/src/reducers/devicesWatering.js
+++ b/src/reducers/devicesWatering.js
@@ -113,7 +113,7 @@ const deviceWatering = (state = initialDevicesWatering, action) => {
       // 行を作成して追加
       var row = Map({
         id: tmpId,
-        device_id: action.params.deviceId,
+        device_id: action.deviceId,
         _state: 'create',
       })
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,11 +1,13 @@
 import { combineReducers } from 'redux';
 import me from './me'
+import device from './device'
 import devicesWatering from './devicesWatering'
 import devicesPyranometer from './devicesPyranometer'
 import devicesSystemLog from './devicesSystemLog'
 
 const karakuriFarmApp = combineReducers({
   me,
+  device,
   devicesWatering,
   devicesPyranometer,
   devicesSystemLog,


### PR DESCRIPTION
#### 変更[1] redux系にdeviceを追加し、各デバイスで共通な部分を委譲
 - deviceのload（Bastetからの取得）
 - appのselect（現在watering/pyranometerのどちらを弄っているのか。必要無かったらそのうち削除する）
 - deviceのselect（KF上でのdeviceの選択）

#### 変更[2] component系に各deviceの基底的なものを追加し、各デバイスで共通な部分を委譲
 - 設定画面の汎化
 - 設定タブ画面の汎化

#### 変更[3] その他
 - チェックボックス変更時にBasteにpost出来ない不具合を修正

 * 今回の変更は、device.name などの共通部分をBastetにpostするための布石です。
 * 今回の変更で、componentなのにstore使ってるじゃんみたいな部分も出てきてますが、移動等は次回以降に行います。