### PR TITLE
同一メールアドレスでのアカウント登録のコード認証をできなくする

### DIFF
--- a/src/actions/me.js
+++ b/src/actions/me.js
@@ -61,7 +61,7 @@ export function confirmMe(pincode) {
     dispatch({ type: Me.CONFIRM_REQUEST });
 
     return new Promise((resolve, reject) => {
-      cognitoUser.confirmRegistration(pincode, true, (error, result) => {
+      cognitoUser.confirmRegistration(pincode, false, (error, result) => {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
今までのユーザー登録の仕様:
- 一つのemailで複数のコード認証済みのアカウントが作成できた。

この実装によるユーザー登録の仕様:
- すでにコード認証済みのアカウントがある場合、そのアカウントと同じemailではコード認証することはできない。
- サインアップ処理まではできてしまう。
- コード認証済みのアカウントだけで見るとemailはユニークになっている。