### PR TITLE
layoutと機能を分割するためにdevicesListを作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "immutablediff": "^0.4.4",
     "immutablepatch": "^0.5.0",
     "moment": "^2.20.1",
+    "prop-types": "^15.7.2",
     "react": "^16.8.2",
     "react-datepicker": "^1.0.4",
     "react-dom": "^16.8.2",

--- a/src/containers/DeviceList.js
+++ b/src/containers/DeviceList.js
@@ -1,0 +1,94 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Menu, Label } from 'semantic-ui-react';
+// import { Link } from 'react-router-dom';
+import GtbUtils from '../js/GtbUtils';
+import Logger from '../js/Logger';
+
+class DeviceList extends Component {
+  constructor(props) {
+    super(props);
+    this.logger = new Logger({prefix: this.constructor.name});
+    this.onClickItem = this.onClickItem.bind(this);
+    this.createMenuItem = this.createMenuItem.bind(this);
+
+    let initialActiveItemId = props.initialActiveItemId ? props.initialActiveItemId : null;
+    let activeItemId = GtbUtils.findOrHead(props.items, 'id', initialActiveItemId);
+    this.state = {
+      activeItemId: activeItemId,
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    // new Logger({prefix: "DeviceList"}).log('getDerivedStateFromProps:', prevState, '->', nextProps);
+    let nextActiveItemId = GtbUtils.findOrHead(nextProps.items, 'id', prevState.activeItemId);
+    if (prevState.nextActiveItemId !== nextActiveItemId) {
+      return {
+        activeItemId: nextActiveItemId
+      };
+    }
+    return null;
+  }
+
+  onClickItem(event, data) {
+    // TODO 保存がされてない場合は変更時に警告する
+    // this.logger.log('onClickItem:', event, data, this.props.items);
+    let item = GtbUtils.find(this.props.items, 'id', data.name);
+    if (item.id !== this.state.activeItemId) {
+      // 変更された場合
+      this.setState({activeItemId: item.id});
+      this.props.onClickItem(item.id)
+    }
+  }
+
+  createMenuItem(item) {
+    this.logger.log('createMenuItem', item)
+    let label = '';
+    if (item.label) {
+      label = <Label color="teal">{item.label}</Label>;
+    }
+
+    return (
+      <Menu.Item
+        // as={Link}
+        // to={item.linkTo ? item.linkTo : item.id}
+        key={item.id}
+        name={item.id}
+        active={this.state.activeItemId === item.id}
+        onClick={this.onClickItem}
+      >
+        {label}
+        {item.name}
+      </Menu.Item>
+    );
+  }
+
+  render() {
+    this.logger.log('render', this.state)
+    const menuItems = this.props.items.map(this.createMenuItem);
+    return (
+      <Menu
+        fluid
+        vertical
+        secondary
+        pointing
+      >
+        {menuItems}
+      </Menu>
+    );
+  }
+}
+
+const propTypesShapeItem = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  linkTo: PropTypes.string,
+})
+DeviceList.propTypes = {
+  items: PropTypes.arrayOf(propTypesShapeItem).isRequired,
+  initialActiveItemId: PropTypes.string,
+  onClickItem: PropTypes.func,
+}
+
+
+export default DeviceList;

--- a/src/containers/DeviceSetting.js
+++ b/src/containers/DeviceSetting.js
@@ -1,85 +1,22 @@
 import React, { Component } from 'react';
-import { Grid, Menu } from 'semantic-ui-react';
+import { Grid } from 'semantic-ui-react';
 import Logger from '../js/Logger';
 import GtbUtils from '../js/GtbUtils';
+import DeviceList from './DeviceList';
 
 export default class DeviceSetting extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      names: [],
-      item: {id: null},
+      activeItem: {id: null},
     };
-    this.logger = new Logger({prefix: 'DeviceSetting'});
+    this.logger = new Logger({prefix: this.constructor.name});
     this.change = this.change.bind(this);
-    this.select = this.select.bind(this);
   }
 
-  componentWillMount() {
-    this.init(this.props.items);
-  }
-
-  componentWillReceiveProps(nextProps, nextState) {
-    this.init(nextProps.items);
-  }
-
-  init(items) {
-    // namesを作成して選択
-    let names = this.toNames(items);
-    this.select(this.state.item.id, names, items);
-  }
-
-  change(event, data, a) {
-    // TODO 保存がされてない場合は変更時に警告する
-    // this.logger.log('change:', event, data);
-    let item = this.props.items[data.index];
-    if (item.id !== this.state.item.id) {
-      // 変更された場合
-      this.select(item.id);
-    }
-  }
-
-  toNames(items) {
-    return items.map(this.toName);
-  }
-
-  toName(element) {
-    return {
-      key: element["id"],
-      name: element["name"],
-    };
-  }
-
-  select(key, names = this.state.names, items = this.props.items) {
-    if (0 === names.length) {
-      // namesがない場合は選択を無効にする
-      this.setState({
-        item: {id: null},
-      });
-      return;
-    }
-
-    if (null === key) {
-      // 何も選択されていない場合は先頭要素を選択する
-      key = names[0].key;
-    }
-
-    names = names.map(v => {
-      if (v.key === key) {
-        v.active = true;
-      } else {
-        delete v.active;
-      }
-      return v;
-    });
-
-    let item = GtbUtils.find(items, 'id', key) || {id: null};
-
-    // this.logger.log('selected:', names, key, items, item);
-    this.setState({
-      names: names,
-      item: item,
-    });
+  change(activeItemId) {
+    let item = GtbUtils.find(this.props.items, 'id', activeItemId);
+    this.setState({activeItem: item});
   }
 
   render() {
@@ -88,19 +25,14 @@ export default class DeviceSetting extends Component {
       <div>
         <Grid columns={2}>
           <Grid.Column width={3}>
-            <Menu
-              fluid
-              vertical
-              secondary
-              pointing
-              items={this.state.names}
-              onItemClick={this.change}
+            <DeviceList
+              items={this.props.items}
+              onClickItem={this.change}
               />
-
           </Grid.Column>
           <Grid.Column stretched width={13}>
             {<this.props.component
-              item = {this.state.item}
+              item = {this.state.activeItem}
             />}
           </Grid.Column>
         </Grid>

--- a/src/js/GtbUtils.js
+++ b/src/js/GtbUtils.js
@@ -134,4 +134,65 @@ export default class GtbUtils {
     return (j1 === j2);
   }
 
+  /**
+   * [findOrHead description]
+   * @param  {[type]} array  [description]
+   * @param  {[type]} column [description]
+   * @param  {[type]} value  [description]
+   * @return {[type]}        [description]
+   *
+   * listの初期表示、またはlistの要素が変更された時に、先頭の要素を選択するためのメソッド。
+   *
+   * 初期表示（valueがnull）の場合は、先頭要素のcolumn値を返却する。
+   * ```js
+   * array=[{id: '1' , id: '2'}]
+   * column='id'
+   * value=null
+   * findOrHead(array, column, value) # '1'
+   * ```
+   *
+   * listの内容が変更された場合、
+   * 先程まで選択されていた要素が存在する場合は同じ値を、
+   * 存在しなくなった場合は先頭要素のcolumn値を返却する。
+   * ```js
+   * array=[{id: '1' , id: '3'}]
+   * column='id'
+   * value='2'
+   * findOrHead(array, column, value) # '1'
+   *
+   * array=[{id: '1' , id: '2', id: '3'}]
+   * column='id'
+   * value='2'
+   * findOrHead(array, column, value) # '2'
+   * ```
+   *
+   * listが空またはnullの場合は、nullを返却する。
+   * ```js
+   * array=[]
+   * column='id'
+   * value='2'
+   * findOrHead(array, column, value) # null
+   *
+   * array=null
+   * column='id'
+   * value='2'
+   * findOrHead(array, column, value) # null
+   * ```
+   */
+  static findOrHead(array, column, value) {
+    if (array === null || array.length === 0) {
+      return null;
+    }
+
+    if (value === null) {
+      return array[0][column];
+    }
+
+    let item = this.find(array, column, value);
+    if (item === null) {
+      return array[0][column];
+    }
+
+    return item[column]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6935,7 +6935,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:


### PR DESCRIPTION
- reactのupdateにより、うまいこと動かなくなっている部分を修正していく。
  - まず、deviceが初期選択時にリストがハイライトされなかったケースを修正。
  - /app/devices/:id/stats みたいなurlハンドリングができるようにするために、router/layout/contentsを分離していく。
- component間のpropsの関係がわからなくならないように、 `prop-types` https://www.npmjs.com/package/prop-types を導入。

![2019-02-17 21 47 32](https://user-images.githubusercontent.com/1407926/52913112-034d7280-32fe-11e9-98bb-4657edb132e9.png)
