### PR TITLE
日射比例潅水の追加項目を実装

### DIFF
--- a/docker_files/web/Dockerfile
+++ b/docker_files/web/Dockerfile
@@ -1,3 +1,5 @@
 FROM node:8.10.0-alpine
 
 WORKDIR /app
+
+ENV CHOKIDAR_USEPOLLING=true

--- a/src/components/part/form/DropdownTimezone.js
+++ b/src/components/part/form/DropdownTimezone.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import Dropdown from '../Dropdown';
+
+import Logger from '../../../js/Logger'
+
+class DropdownTimezone extends Component {
+  constructor(props) {
+    super(props);
+    this.logger = new Logger({prefix: this.constructor.name});
+  }
+
+  render() {
+    let items = [
+      // "Etc/UTC", とりあえず日本のみ
+      "Asia/Tokyo",
+    ];
+
+    // this.logger.log("render:", options, '->', this.props.value);
+    return (
+      <Dropdown
+        items={items}
+        {...this.props}
+      />
+    );
+  }
+}
+export default DropdownTimezone;

--- a/src/containers/DevicesSummary.js
+++ b/src/containers/DevicesSummary.js
@@ -5,6 +5,7 @@ import Logger from '../js/Logger'
 import Header from '../components/part/Header'
 import Field from '../components/part/Field';
 import Input from '../components/part/Input';
+import DropdownTimezone from '../components/part/form/DropdownTimezone';
 
 import DevicesMonitor from './DevicesMonitor';
 
@@ -53,6 +54,14 @@ class DevicesSummary extends Component {
           <Field label='device_type' text={this.props.item.device_type} />
           <Field label='name'>
             <Input.Hash size='large' fluid hash={this.props.item} column='name' callback={this.update} />
+          </Field>
+          <Field label='timezone'>
+            <DropdownTimezone
+              fluid
+              selection
+              value={this.props.item.timezone}
+              callback={(value) => { this.update('timezone', value, null)}}
+            />
           </Field>
           <Field label='software_version' text={this.props.item.software_version} />
           <Field label='model_number' text={this.props.item.model_number} />

--- a/src/containers/MachinesRadiationalWateringConfigurations.js
+++ b/src/containers/MachinesRadiationalWateringConfigurations.js
@@ -134,6 +134,16 @@ class MachinesRadiationalWateringConfigurations extends React.Component {
         width: 100,
         customCell: { type: 'input', formatter: new DecimalFormatter(), callback: this.update }
       }, {
+        Header: 'Base',
+        accessor: 'duration_of_base',
+        width: 100,
+        customCell: { type: 'input', formatter: new DecimalFormatter(), callback: this.update }
+      }, {
+        Header: 'Morning',
+        accessor: 'duration_of_morning',
+        width: 100,
+        customCell: { type: 'input', formatter: new DecimalFormatter(), callback: this.update }
+      }, {
         Header: '-',
         accessor: 'remove',
         width: 48,

--- a/src/containers/MachinesSummary.js
+++ b/src/containers/MachinesSummary.js
@@ -67,7 +67,7 @@ class MachinesSummary extends Component {
               value={this.props.item.watering_id}
               callback={(value) => { this.update('watering_id', value, null)}}
             />
-         </Field>
+          </Field>
           <Field label='pyranometer'>
             <Dropdown
               fluid

--- a/src/reducers/device.js
+++ b/src/reducers/device.js
@@ -64,6 +64,7 @@ const device = (state = initialDevice, action) => {
             software_version: value["software_version"],
             model_number: value["model_number"],
             organization_id: value["organization_id"],
+            timezone: value["timezone"],
             heartbeated_at: GtbUtils.dateString(new Date(value["heartbeated_at"])),
             inserted_at: GtbUtils.dateString(new Date(value["inserted_at"])),
             updated_at: GtbUtils.dateString(new Date(value["updated_at"])),


### PR DESCRIPTION
#155 の実装

- デバイスにtimezoneを追加
![localhost_3000_app_devices_waterings](https://user-images.githubusercontent.com/1407926/77514927-06c90b00-6ebb-11ea-8792-2999289be859.png)

- 日射比例潅水に朝一潅水時間/基礎潅水時間を追加
![localhost_3000_app_devices_waterings (1)](https://user-images.githubusercontent.com/1407926/77514933-09c3fb80-6ebb-11ea-80db-8dd29395eefb.png)
